### PR TITLE
added blue green strategy

### DIFF
--- a/__tests__/blue-green-helper.test.ts
+++ b/__tests__/blue-green-helper.test.ts
@@ -1,0 +1,784 @@
+import * as fs from 'fs';
+import * as inputParam from '../src/input-parameters';
+import * as fileHelper from '../src/utilities/files-helper';
+import {
+	Kubectl,
+} from '../src/kubectl-object-model';
+import {
+	mocked
+} from 'ts-jest/utils';
+import * as kubectlUtils from '../src/utilities/kubectl-util';
+
+var path = require('path');
+const inputParamMock = mocked(inputParam, true);
+var deploymentYaml = "";
+
+import * as blueGreenHelper from '../src/utilities/strategy-helpers/blue-green-helper';
+import * as blueGreenHelperService from '../src/utilities/strategy-helpers/service-blue-green-helper';
+import * as blueGreenHelperIngress from '../src/utilities/strategy-helpers/ingress-blue-green-helper';
+import * as blueGreenHelperSMI from '../src/utilities/strategy-helpers/smi-blue-green-helper';
+
+beforeAll(() => {
+	deploymentYaml = fs.readFileSync(path.join(__dirname, 'manifests', 'bg.yml'), 'utf8');
+	process.env["KUBECONFIG"] = 'kubeConfig';
+});
+
+test("deployBlueGreen - checks if deployment can be done, then deploys", () => {
+	const fileHelperMock = mocked(fileHelper, true);
+	const kubeCtl: jest.Mocked < Kubectl > = new Kubectl("") as any;
+	let temp = {
+		stdout: undefined
+	};
+	fileHelperMock.writeObjectsToFile = jest.fn().mockReturnValue('hello');
+	kubeCtl.apply = jest.fn().mockReturnValue('');
+	kubeCtl.getResource = jest.fn().mockReturnValue(JSON.parse(JSON.stringify(temp)));
+	const readFileSpy = jest.spyOn(fs, 'readFileSync').mockImplementation(() => deploymentYaml);
+
+	//Invoke and assert
+	expect(blueGreenHelperService.deployBlueGreen(kubeCtl, ['manifests/bg.yaml'])).toMatchObject({
+		"newFilePaths": "hello",
+		"result": ""
+	});
+	expect(readFileSpy).toBeCalledWith("manifests/bg.yaml");
+	expect(fileHelperMock.writeObjectsToFile).toBeCalled();
+	expect(kubeCtl.apply).toBeCalled();
+});
+
+test("blueGreenPromote - checks if in deployed state and then promotes", () => {
+	const fileHelperMock = mocked(fileHelper, true);
+	const kubeCtl: jest.Mocked < Kubectl > = new Kubectl("") as any;
+	let temp = {
+		stdout: JSON.stringify({
+			"apiVersion": "v1",
+			"kind": "Service",
+			"metadata": {
+				"name": "testservice"
+			},
+			"spec": {
+				"selector": {
+					"app": "testapp",
+					"k8s.deploy.color": "green"
+				},
+				"ports": [{
+					"protocol": "TCP",
+					"port": 80,
+					"targetPort": 80
+				}]
+			}
+		})
+	};
+	fileHelperMock.writeObjectsToFile = jest.fn().mockReturnValue('hello');
+	kubeCtl.apply = jest.fn().mockReturnValue('');
+	kubeCtl.getResource = jest.fn().mockReturnValue(JSON.parse(JSON.stringify(temp)));
+	const readFileSpy = jest.spyOn(fs, 'readFileSync').mockImplementation(() => deploymentYaml);
+	//Invoke and assert
+	const manifestObjects = blueGreenHelper.getManifestObjects(['manifests/bg.yaml']);
+	expect(blueGreenHelperService.blueGreenPromote(kubeCtl, manifestObjects)).toMatchObject({});
+	expect(readFileSpy).toBeCalledWith("manifests/bg.yaml");
+	expect(kubeCtl.apply).toBeCalledWith("hello");
+	expect(fileHelperMock.writeObjectsToFile).toBeCalled();
+});
+
+test("blueGreenReject - routes servcies to old deployment and deletes new deployment", () => {
+	const fileHelperMock = mocked(fileHelper, true);
+	const kubeCtl: jest.Mocked < Kubectl > = new Kubectl("") as any;
+	let temp = {
+		stdout: JSON.stringify({
+			"apiVersion": "apps/v1beta1",
+			"kind": "Deployment",
+			"metadata": {
+				"name": "testapp",
+				"labels": {
+					"k8s.deploy.color": "none"
+				}
+			},
+			"spec": {
+				"selector": {
+					"matchLabels": {
+						"app": "testapp",
+						"k8s.deploy.color": "none"
+					}
+				},
+				"replicas": 1,
+				"template": {
+					"metadata": {
+						"labels": {
+							"app": "testapp",
+							"k8s.deploy.color": "none"
+						}
+					},
+					"spec": {
+						"containers": [{
+							"name": "testapp",
+							"image": "testcr.azurecr.io/testapp",
+							"ports": [{
+								"containerPort": 80
+							}]
+						}]
+					}
+				}
+			}
+		})
+	};
+	kubeCtl.delete = jest.fn().mockReturnValue('');
+	fileHelperMock.writeObjectsToFile = jest.fn().mockReturnValue('hello');
+	kubeCtl.apply = jest.fn().mockReturnValue('');
+	kubeCtl.getResource = jest.fn().mockReturnValue(JSON.parse(JSON.stringify(temp)));
+	const readFileSpy = jest.spyOn(fs, 'readFileSync').mockImplementation(() => deploymentYaml);
+
+	//Invoke and assert
+	expect(blueGreenHelperService.blueGreenReject(kubeCtl, ['manifests/bg.yaml'])).toMatchObject({});
+	expect(kubeCtl.delete).toBeCalledWith(["Deployment", "testapp-green"]);
+	expect(readFileSpy).toBeCalledWith("manifests/bg.yaml");
+	expect(fileHelperMock.writeObjectsToFile).toBeCalled();
+	expect(kubeCtl.getResource).toBeCalledWith("Deployment", "testapp");
+});
+
+test("blueGreenReject - deletes services if old deployment does not exist", () => {
+	const fileHelperMock = mocked(fileHelper, true);
+	const kubeCtl: jest.Mocked < Kubectl > = new Kubectl("") as any;
+	let temp = {
+		stdout: undefined
+	};
+	fileHelperMock.writeObjectsToFile = jest.fn().mockReturnValue('hello');
+	kubeCtl.apply = jest.fn().mockReturnValue('');
+	kubeCtl.delete = jest.fn().mockReturnValue('');
+	kubeCtl.getResource = jest.fn().mockReturnValue(JSON.parse(JSON.stringify(temp)));
+	const readFileSpy = jest.spyOn(fs, 'readFileSync').mockImplementation(() => deploymentYaml);
+
+	//Invoke and assert
+	expect(blueGreenHelperService.blueGreenReject(kubeCtl, ['manifests/bg.yaml'])).toMatchObject({});
+	expect(kubeCtl.delete).toBeCalledWith(["Deployment", "testapp-green"]);
+	expect(kubeCtl.delete).toBeCalledWith(["Service", "testservice"]);
+	expect(readFileSpy).toBeCalledWith("manifests/bg.yaml");
+	expect(fileHelperMock.writeObjectsToFile).toBeCalled();
+	expect(kubeCtl.getResource).toBeCalledWith("Deployment", "testapp");
+});
+
+test("isIngressRoute() - returns true if route-method is ingress", () => {
+	// default is service
+	expect(blueGreenHelperIngress.isIngressRoute()).toBeFalsy();
+});
+
+test("isIngressRoute() - returns true if route-method is ingress", () => {
+	inputParamMock.routeMethod = 'ingress'
+	expect(blueGreenHelperIngress.isIngressRoute()).toBeTruthy();
+});
+
+test("deployBlueGreenIngress - creates deployments, services and other non ingress objects", () => {
+	const fileHelperMock = mocked(fileHelper, true);
+	const kubeCtl: jest.Mocked < Kubectl > = new Kubectl("") as any;
+	let temp = {
+		stdout: undefined
+	};
+	fileHelperMock.writeObjectsToFile = jest.fn().mockReturnValue('hello');
+	kubeCtl.apply = jest.fn().mockReturnValue('');
+	kubeCtl.getResource = jest.fn().mockReturnValue(JSON.parse(JSON.stringify(temp)));
+	const readFileSpy = jest.spyOn(fs, 'readFileSync').mockImplementation(() => deploymentYaml);
+
+	//Invoke and assert
+	expect(blueGreenHelperIngress.deployBlueGreenIngress(kubeCtl, ['manifests/bg.yaml'])).toMatchObject({
+		"newFilePaths": "hello",
+		"result": ""
+	});
+	expect(readFileSpy).toBeCalledWith("manifests/bg.yaml");
+	expect(kubeCtl.apply).toBeCalledWith("hello");
+});
+
+test("blueGreenPromoteIngress - checks if in deployed state and then promotes ingress", () => {
+	const fileHelperMock = mocked(fileHelper, true);
+	const kubeCtl: jest.Mocked < Kubectl > = new Kubectl("") as any;
+	fileHelperMock.writeObjectsToFile = jest.fn().mockReturnValue('hello');
+	kubeCtl.apply = jest.fn().mockReturnValue('');
+	const readFileSpy = jest.spyOn(fs, 'readFileSync').mockImplementation(() => deploymentYaml);
+	let temp = {
+		stdout: JSON.stringify({
+			"apiVersion": "networking.k8s.io/v1beta1",
+			"kind": "Ingress",
+			"metadata": {
+				"name": "testingress",
+				"labels": {
+					"k8s.deploy.color": "green"
+				},
+				"annotations": {
+					"nginx.ingress.kubernetes.io/rewrite-target": "/"
+				}
+			},
+			"spec": {
+				"rules": [{
+					"http": {
+						"paths": [{
+							"path": "/testpath",
+							"pathType": "Prefix",
+							"backend": {
+								"serviceName": "testservice-green",
+								"servicePort": 80
+							}
+						}]
+					}
+				}]
+			}
+		})
+	};
+	kubeCtl.getResource = jest.fn().mockReturnValue(JSON.parse(JSON.stringify(temp)));
+	const manifestObjects = blueGreenHelper.getManifestObjects(['manifests/bg.yaml']);
+	//Invoke and assert
+	expect(blueGreenHelperIngress.blueGreenPromoteIngress(kubeCtl, manifestObjects)).toMatchObject({});
+	expect(readFileSpy).toBeCalledWith("manifests/bg.yaml");
+	expect(kubeCtl.apply).toBeCalledWith("hello");
+});
+
+test("blueGreenRejectIngress - routes ingress to stable services and deletes new deployments and services", () => {
+	const fileHelperMock = mocked(fileHelper, true);
+	const kubeCtl: jest.Mocked < Kubectl > = new Kubectl("") as any;
+	fileHelperMock.writeObjectsToFile = jest.fn().mockReturnValue('hello');
+	kubeCtl.apply = jest.fn().mockReturnValue('');
+	kubeCtl.delete = jest.fn().mockReturnValue('');
+	const readFileSpy = jest.spyOn(fs, 'readFileSync').mockImplementation(() => deploymentYaml);
+
+	//Invoke and assert
+	expect(blueGreenHelperIngress.blueGreenRejectIngress(kubeCtl, ['manifests/bg.yaml'])).toMatchObject({});
+	expect(kubeCtl.delete).toBeCalledWith(["Deployment", "testapp-green"]);
+	expect(kubeCtl.delete).toBeCalledWith(["Service", "testservice-green"]);
+	expect(readFileSpy).toBeCalledWith("manifests/bg.yaml");
+	expect(fileHelperMock.writeObjectsToFile).toBeCalled();
+});
+
+test("isSMIRoute() - returns true if route-method is smi", () => {
+	inputParamMock.routeMethod = 'smi'
+	expect(blueGreenHelperSMI.isSMIRoute()).toBeTruthy();
+});
+
+test("isSMIRoute() - returns true if route-method is smi", () => {
+	inputParamMock.routeMethod = 'ingress'
+	expect(blueGreenHelperSMI.isSMIRoute()).toBeFalsy();
+});
+
+test("deployBlueGreenSMI - checks if deployment can be done, then deploys along this auxiliary services and trafficsplit", () => {
+	const fileHelperMock = mocked(fileHelper, true);
+	const kubeCtl: jest.Mocked < Kubectl > = new Kubectl("") as any;
+	let temp = {
+		stdout: undefined
+	};
+	fileHelperMock.writeObjectsToFile = jest.fn().mockReturnValue('hello');
+	kubeCtl.apply = jest.fn().mockReturnValue('');
+	kubeCtl.getResource = jest.fn().mockReturnValue(JSON.parse(JSON.stringify(temp)));
+	const readFileSpy = jest.spyOn(fs, 'readFileSync').mockImplementation(() => deploymentYaml);
+	const kubectlUtilsMock = mocked(kubectlUtils, true);
+	kubectlUtilsMock.getTrafficSplitAPIVersion = jest.fn().mockReturnValue('split.smi-spec.io/v1alpha2');
+
+	//Invoke and assert
+	expect(blueGreenHelperSMI.deployBlueGreenSMI(kubeCtl, ['manifests/bg.yaml'])).toMatchObject({
+		"newFilePaths": "hello",
+		"result": ""
+	});
+	expect(readFileSpy).toBeCalledWith("manifests/bg.yaml");
+	expect(fileHelperMock.writeObjectsToFile).toBeCalled();
+});
+
+test("blueGreenPromoteSMI - checks weights of trafficsplit and then deploys", () => {
+	const fileHelperMock = mocked(fileHelper, true);
+	const kubeCtl: jest.Mocked < Kubectl > = new Kubectl("") as any;
+	fileHelperMock.writeObjectsToFile = jest.fn().mockReturnValue('hello');
+	kubeCtl.apply = jest.fn().mockReturnValue('');
+	const readFileSpy = jest.spyOn(fs, 'readFileSync').mockImplementation(() => deploymentYaml);
+	let temp = {
+		stdout: JSON.stringify({
+			"apiVersion": "split.smi-spec.io/v1alpha2",
+			"kind": "TrafficSplit",
+			"metadata": {
+				"name": "testservice-rollout"
+			},
+			"spec": {
+				"service": "testservice",
+				"backends": [{
+						"service": "testservice-stable",
+						"weight": 0
+					},
+					{
+						"service": "testservice-green",
+						"weight": 100
+					}
+				]
+			}
+		})
+	};
+	kubeCtl.getResource = jest.fn().mockReturnValue(JSON.parse(JSON.stringify(temp)));
+	const manifestObjects = blueGreenHelper.getManifestObjects(['manifests/bg.yaml']);
+	//Invoke and assert
+	expect(blueGreenHelperSMI.blueGreenPromoteSMI(kubeCtl, manifestObjects)).toMatchObject({});
+	expect(readFileSpy).toBeCalledWith("manifests/bg.yaml");
+});
+
+test("blueGreenRejectSMI - routes servcies to old deployment and deletes new deployment, auxiliary services and trafficsplit", () => {
+	const fileHelperMock = mocked(fileHelper, true);
+	const kubeCtl: jest.Mocked < Kubectl > = new Kubectl("") as any;
+	let temp = {
+		stdout: JSON.stringify({
+			"apiVersion": "apps/v1beta1",
+			"kind": "Deployment",
+			"metadata": {
+				"name": "testapp",
+				"labels": {
+					"k8s.deploy.color": "none"
+				}
+			},
+			"spec": {
+				"selector": {
+					"matchLabels": {
+						"app": "testapp",
+						"k8s.deploy.color": "none"
+
+					}
+				},
+				"replicas": 1,
+				"template": {
+					"metadata": {
+						"labels": {
+							"app": "testapp",
+							"k8s.deploy.color": "none"
+						}
+					},
+					"spec": {
+						"containers": [{
+							"name": "testapp",
+							"image": "testcr.azurecr.io/testapp",
+							"ports": [{
+								"containerPort": 80
+							}]
+						}]
+					}
+				}
+			}
+		})
+	};
+	kubeCtl.delete = jest.fn().mockReturnValue('');
+	fileHelperMock.writeObjectsToFile = jest.fn().mockReturnValue('hello');
+	kubeCtl.apply = jest.fn().mockReturnValue('');
+	kubeCtl.getResource = jest.fn().mockReturnValue(JSON.parse(JSON.stringify(temp)));
+	const readFileSpy = jest.spyOn(fs, 'readFileSync').mockImplementation(() => deploymentYaml);
+
+	//Invoke and assert
+	expect(blueGreenHelperSMI.blueGreenRejectSMI(kubeCtl, ['manifests/bg.yaml'])).toMatchObject({});
+	expect(kubeCtl.delete).toBeCalledWith(["Deployment", "testapp-green"]);
+	expect(kubeCtl.delete).toBeCalledWith(["Service", "testservice-green"]);
+	expect(kubeCtl.delete).toBeCalledWith(["Service", "testservice-stable"]);
+	expect(kubeCtl.delete).toBeCalledWith(["TrafficSplit", "testservice-rollout"]);
+	expect(readFileSpy).toBeCalledWith("manifests/bg.yaml");
+	expect(kubeCtl.getResource).toBeCalledWith("Deployment", "testapp");
+});
+
+test("blueGreenRejectSMI - deletes service if stable deployment doesn't exist", () => {
+	const fileHelperMock = mocked(fileHelper, true);
+	const kubeCtl: jest.Mocked < Kubectl > = new Kubectl("") as any;
+	let temp = {
+		stdout: undefined
+	};
+	kubeCtl.delete = jest.fn().mockReturnValue('');
+	fileHelperMock.writeObjectsToFile = jest.fn().mockReturnValue('hello');
+	kubeCtl.apply = jest.fn().mockReturnValue('');
+	kubeCtl.getResource = jest.fn().mockReturnValue(JSON.parse(JSON.stringify(temp)));
+	const readFileSpy = jest.spyOn(fs, 'readFileSync').mockImplementation(() => deploymentYaml);
+
+	//Invoke and assert
+	expect(blueGreenHelperSMI.blueGreenRejectSMI(kubeCtl, ['manifests/bg.yaml'])).toMatchObject({});
+	expect(kubeCtl.delete).toBeCalledWith(["Deployment", "testapp-green"]);
+	expect(kubeCtl.delete).toBeCalledWith(["Service", "testservice"]);
+	expect(kubeCtl.delete).toBeCalledWith(["Service", "testservice-green"]);
+	expect(kubeCtl.delete).toBeCalledWith(["Service", "testservice-stable"]);
+	expect(kubeCtl.delete).toBeCalledWith(["TrafficSplit", "testservice-rollout"]);
+	expect(readFileSpy).toBeCalledWith("manifests/bg.yaml");
+	expect(kubeCtl.getResource).toBeCalledWith("Deployment", "testapp");
+});
+
+// other functions and branches
+test("blueGreenRouteIngress - routes to green services in nextlabel is green", () => {
+	const kubeCtl: jest.Mocked < Kubectl > = new Kubectl("") as any;
+	const fileHelperMock = mocked(fileHelper, true);
+	const ingEntList = [{
+			"apiVersion": "networking.k8s.io/v1beta1",
+			"kind": "Ingress",
+			"metadata": {
+				"name": "test-ingress",
+				"annotations": {
+					"nginx.ingress.kubernetes.io/rewrite-target": "/"
+				},
+			},
+			"spec": {
+				"rules": [{
+					"http": {
+						"paths": [{
+								"path": "/testpath",
+								"pathType": "Prefix",
+								"backend": {
+									"serviceName": "testservice",
+									"servicePort": 80
+								}
+							},
+							{
+								"path": "/testpath",
+								"pathType": "Prefix",
+								"backend": {
+									"serviceName": "random",
+									"servicePort": 80
+								}
+							}
+						]
+					}
+				}]
+			}
+		},
+		{
+			"apiVersion": "networking.k8s.io/v1beta1",
+			"kind": "Ingress",
+			"metadata": {
+				"name": "test-ingress",
+				"annotations": {
+					"nginx.ingress.kubernetes.io/rewrite-target": "/"
+				},
+			},
+			"spec": {
+				"rules": [{
+					"http": {
+						"paths": [{
+							"path": "/testpath",
+							"pathType": "Prefix",
+							"backend": {
+								"serviceName": "random",
+								"servicePort": 80
+							}
+						}]
+					}
+				}]
+			}
+		}
+	];
+
+	const serEntList = [{
+		"apiVersion": "v1",
+		"kind": "Service",
+		"metadata": {
+			"name": "testservice"
+		},
+		"spec": {
+			"selector": {
+				"app": "testapp",
+			},
+			"ports": [{
+				"protocol": "TCP",
+				"port": 80,
+				"targetPort": 80
+			}]
+		}
+	}];
+
+	let serviceEntityMap = new Map<string, string>();
+	serviceEntityMap.set('testservice', 'testservice-green');
+	fileHelperMock.writeObjectsToFile = jest.fn().mockReturnValue('hello');
+	kubeCtl.apply = jest.fn().mockReturnValue('');
+
+	//Invoke and assert
+	expect(blueGreenHelperIngress.blueGreenRouteIngress(kubeCtl, 'green', serviceEntityMap, serEntList, ingEntList));
+	expect(kubeCtl.apply).toBeCalled();
+	expect(fileHelperMock.writeObjectsToFile).toBeCalled();
+});
+
+test("shouldWePromoteIngress - throws if routed ingress does not exist", () => {
+	const kubeCtl: jest.Mocked < Kubectl > = new Kubectl("") as any;
+	let temp = {
+		stdout: undefined
+	}
+
+	const ingEntList = [{
+		"apiVersion": "networking.k8s.io/v1beta1",
+		"kind": "Ingress",
+		"metadata": {
+			"name": "test-ingress",
+			"annotations": {
+				"nginx.ingress.kubernetes.io/rewrite-target": "/"
+			}
+		},
+		"spec": {
+			"rules": [{
+				"http": {
+					"paths": [{
+						"path": "/testpath",
+						"pathType": "Prefix",
+						"backend": {
+							"serviceName": "testservice",
+							"servicePort": 80
+						}
+					}]
+				}
+			}]
+		}
+	}];
+
+	let serviceEntityMap = new Map<string, string>();
+	serviceEntityMap.set('testservice', 'testservice-green');
+
+	kubeCtl.getResource = jest.fn().mockReturnValue(JSON.parse(JSON.stringify(temp)));
+
+	//Invoke and assert
+	expect(blueGreenHelperIngress.validateIngressState(kubeCtl, ingEntList, serviceEntityMap)).toBeFalsy();
+});
+
+test("shouldWePromoteSMI - throws if trafficsplit in wrong state", () => {
+	const kubeCtl: jest.Mocked < Kubectl > = new Kubectl("") as any;
+	let temp = {
+		stdout: JSON.stringify({
+			"apiVersion": "split.smi-spec.io/v1alpha2",
+			"kind": "TrafficSplit",
+			"metadata": {
+				"name": "testservice-rollout"
+			},
+			"spec": {
+				"service": "testservice",
+				"backends": [{
+						"service": "testservice-stable",
+						"weight": 100
+					},
+					{
+						"service": "testservice-green",
+						"weight": 0
+					}
+				]
+			}
+		})
+	}
+
+	const depEntList = [{
+		"apiVersion": "apps/v1beta1",
+		"kind": "Deployment",
+		"metadata": {
+			"name": "testapp",
+		},
+		"spec": {
+			"selector": {
+				"matchLabels": {
+					"app": "testapp",
+				}
+			},
+			"replicas": 1,
+			"template": {
+				"metadata": {
+					"labels": {
+						"app": "testapp",
+					}
+				},
+				"spec": {
+					"containers": [{
+						"name": "testapp",
+						"image": "testcr.azurecr.io/testapp",
+						"ports": [{
+							"containerPort": 80
+						}]
+					}]
+				}
+			}
+		}
+	}];
+
+	const serEntList = [{
+		"apiVersion": "v1",
+		"kind": "Service",
+		"metadata": {
+			"name": "testservice"
+		},
+		"spec": {
+			"selector": {
+				"app": "testapp",
+			},
+			"ports": [{
+				"protocol": "TCP",
+				"port": 80,
+				"targetPort": 80
+			}]
+		}
+	}];
+	kubeCtl.getResource = jest.fn().mockReturnValue(JSON.parse(JSON.stringify(temp)));
+
+	//Invoke and assert
+	expect(blueGreenHelperSMI.validateTrafficSplitState(kubeCtl, depEntList, serEntList)).toBeFalsy();
+});
+
+test("shouldWePromoteSMI - throws if trafficsplit in wrong state", () => {
+	const kubeCtl: jest.Mocked < Kubectl > = new Kubectl("") as any;
+	let temp = {
+		stdout: JSON.stringify({
+			"apiVersion": "split.smi-spec.io/v1alpha2",
+			"kind": "TrafficSplit",
+			"metadata": {
+				"name": "testservice-rollout"
+			},
+			"spec": {
+				"service": "testservice",
+				"backends": [{
+						"service": "testservice-stable",
+						"weight": 0
+					},
+					{
+						"service": "testservice-green",
+						"weight": 0
+					}
+				]
+			}
+		})
+	}
+
+	const depEntList = [{
+		"apiVersion": "apps/v1beta1",
+		"kind": "Deployment",
+		"metadata": {
+			"name": "testapp",
+		},
+		"spec": {
+			"selector": {
+				"matchLabels": {
+					"app": "testapp",
+				}
+			},
+			"replicas": 1,
+			"template": {
+				"metadata": {
+					"labels": {
+						"app": "testapp",
+					}
+				},
+				"spec": {
+					"containers": [{
+						"name": "testapp",
+						"image": "testcr.azurecr.io/testapp",
+						"ports": [{
+							"containerPort": 80
+						}]
+					}]
+				}
+			}
+		}
+	}];
+
+	const serEntList = [{
+		"apiVersion": "v1",
+		"kind": "Service",
+		"metadata": {
+			"name": "testservice"
+		},
+		"spec": {
+			"selector": {
+				"app": "testapp",
+			},
+			"ports": [{
+				"protocol": "TCP",
+				"port": 80,
+				"targetPort": 80
+			}]
+		}
+	}];
+	kubeCtl.getResource = jest.fn().mockReturnValue(JSON.parse(JSON.stringify(temp)));
+
+	//Invoke and assert
+	const thr = () => 
+	expect(blueGreenHelperSMI.validateTrafficSplitState(kubeCtl, depEntList, serEntList)).toBeFalsy();
+});
+
+test("getSuffix() - returns BLUE_GREEN_SUFFIX if BLUE_GREEN_NEW_LABEL_VALUE is given, else emrty string", () => {
+	expect(blueGreenHelper.getSuffix('green')).toBe('-green');
+});
+
+test("getSuffix() - returns BLUE_GREEN_SUFFIX if BLUE_GREEN_NEW_LABEL_VALUE is given, else emrty string", () => {
+	expect(blueGreenHelper.getSuffix('random')).toBe('');
+});
+
+test("getServiceSpacLabel() - returns empty string if BLUE_GREEN_VERSION_LABEL in spec selector doesn't exist", () => {
+	let input = {
+		"apiVersion": "apps/v1",
+		"kind": "Deployment",
+		"metadata": {
+			"name": "sample-deployment"
+		},
+		"spec": {
+			"selector": {
+				"matchLabels": {
+					"app": "sample",
+					"k8s.deploy.color": "green"
+				}
+			},
+			"template": {
+				"metadata": {
+					"labels": {
+						"app": "sample"
+					},
+					"annotations": {
+						"prometheus.io/scrape": "true",
+						"prometheus.io/port": "8888"
+					}
+				},
+				"spec": {
+					"containers": [{
+						"name": "sample",
+						"image": "tsugunt/sample:v34",
+						"ports": [{
+							"containerPort": 8888
+						}]
+					}]
+				}
+			}
+		}
+	}
+	expect(blueGreenHelperService.getServiceSpecLabel(input)).toBe('');
+});
+
+test("getDeploymentMatchLabels() - return false is input doesnt have matchLabels", () => {
+	let input = {
+		"apiVersion": "v1",
+		"kind": "Service",
+		"metadata": {
+			"name": "sample-service"
+		},
+		"spec": {
+			"selector": {
+				"app": "sample",
+				"k8s.deploy.color": "green"
+			},
+			"ports": [{
+				"protocol": "TCP",
+				"port": 80,
+				"targetPort": 8888,
+				"nodePort": 31002
+			}],
+			"type": "NodePort"
+		}
+	}
+
+	expect(blueGreenHelper.getDeploymentMatchLabels(input)).toBeFalsy();
+});
+
+test("getServiceSelector() - return false if spec selector does not exist", () => {
+	let input = {
+		"apiVersion": "networking.k8s.io/v1beta1",
+		"kind": "Ingress",
+		"metadata": {
+			"name": "test-ingress",
+			"annotations": {
+				"nginx.ingress.kubernetes.io/rewrite-target": "/"
+			}
+		},
+		"spec": {
+			"rules": [{
+				"http": {
+					"paths": [{
+						"path": "/testpath",
+						"pathType": "Prefix",
+						"backend": {
+							"serviceName": "test",
+							"servicePort": 80
+						}
+					}]
+				}
+			}]
+		}
+	}
+
+	expect(blueGreenHelper.getServiceSelector(input)).toBeFalsy();
+});

--- a/__tests__/blue-green-helper.test.ts
+++ b/__tests__/blue-green-helper.test.ts
@@ -73,7 +73,7 @@ test("blueGreenPromote - checks if in deployed state and then promotes", () => {
 	const readFileSpy = jest.spyOn(fs, 'readFileSync').mockImplementation(() => deploymentYaml);
 	//Invoke and assert
 	const manifestObjects = blueGreenHelper.getManifestObjects(['manifests/bg.yaml']);
-	expect(blueGreenHelperService.blueGreenPromote(kubeCtl, manifestObjects)).toMatchObject({});
+	expect(blueGreenHelperService.promoteBlueGreenService(kubeCtl, manifestObjects)).toMatchObject({});
 	expect(readFileSpy).toBeCalledWith("manifests/bg.yaml");
 	expect(kubeCtl.apply).toBeCalledWith("hello");
 	expect(fileHelperMock.writeObjectsToFile).toBeCalled();
@@ -223,7 +223,7 @@ test("blueGreenPromoteIngress - checks if in deployed state and then promotes in
 	kubeCtl.getResource = jest.fn().mockReturnValue(JSON.parse(JSON.stringify(temp)));
 	const manifestObjects = blueGreenHelper.getManifestObjects(['manifests/bg.yaml']);
 	//Invoke and assert
-	expect(blueGreenHelperIngress.blueGreenPromoteIngress(kubeCtl, manifestObjects)).toMatchObject({});
+	expect(blueGreenHelperIngress.promoteBlueGreenIngress(kubeCtl, manifestObjects)).toMatchObject({});
 	expect(readFileSpy).toBeCalledWith("manifests/bg.yaml");
 	expect(kubeCtl.apply).toBeCalledWith("hello");
 });
@@ -306,7 +306,7 @@ test("blueGreenPromoteSMI - checks weights of trafficsplit and then deploys", ()
 	kubeCtl.getResource = jest.fn().mockReturnValue(JSON.parse(JSON.stringify(temp)));
 	const manifestObjects = blueGreenHelper.getManifestObjects(['manifests/bg.yaml']);
 	//Invoke and assert
-	expect(blueGreenHelperSMI.blueGreenPromoteSMI(kubeCtl, manifestObjects)).toMatchObject({});
+	expect(blueGreenHelperSMI.promoteBlueGreenSMI(kubeCtl, manifestObjects)).toMatchObject({});
 	expect(readFileSpy).toBeCalledWith("manifests/bg.yaml");
 });
 
@@ -363,7 +363,7 @@ test("blueGreenRejectSMI - routes servcies to old deployment and deletes new dep
 	expect(kubeCtl.delete).toBeCalledWith(["Deployment", "testapp-green"]);
 	expect(kubeCtl.delete).toBeCalledWith(["Service", "testservice-green"]);
 	expect(kubeCtl.delete).toBeCalledWith(["Service", "testservice-stable"]);
-	expect(kubeCtl.delete).toBeCalledWith(["TrafficSplit", "testservice-rollout"]);
+	expect(kubeCtl.delete).toBeCalledWith(["TrafficSplit", "testservice-trafficsplit"]);
 	expect(readFileSpy).toBeCalledWith("manifests/bg.yaml");
 	expect(kubeCtl.getResource).toBeCalledWith("Deployment", "testapp");
 });
@@ -386,7 +386,7 @@ test("blueGreenRejectSMI - deletes service if stable deployment doesn't exist", 
 	expect(kubeCtl.delete).toBeCalledWith(["Service", "testservice"]);
 	expect(kubeCtl.delete).toBeCalledWith(["Service", "testservice-green"]);
 	expect(kubeCtl.delete).toBeCalledWith(["Service", "testservice-stable"]);
-	expect(kubeCtl.delete).toBeCalledWith(["TrafficSplit", "testservice-rollout"]);
+	expect(kubeCtl.delete).toBeCalledWith(["TrafficSplit", "testservice-trafficsplit"]);
 	expect(readFileSpy).toBeCalledWith("manifests/bg.yaml");
 	expect(kubeCtl.getResource).toBeCalledWith("Deployment", "testapp");
 });
@@ -520,17 +520,17 @@ test("shouldWePromoteIngress - throws if routed ingress does not exist", () => {
 	kubeCtl.getResource = jest.fn().mockReturnValue(JSON.parse(JSON.stringify(temp)));
 
 	//Invoke and assert
-	expect(blueGreenHelperIngress.validateIngressState(kubeCtl, ingEntList, serviceEntityMap)).toBeFalsy();
+	expect(blueGreenHelperIngress.validateIngressesState(kubeCtl, ingEntList, serviceEntityMap)).toBeFalsy();
 });
 
-test("shouldWePromoteSMI - throws if trafficsplit in wrong state", () => {
+test("validateTrafficSplitState - throws if trafficsplit in wrong state", () => {
 	const kubeCtl: jest.Mocked < Kubectl > = new Kubectl("") as any;
 	let temp = {
 		stdout: JSON.stringify({
 			"apiVersion": "split.smi-spec.io/v1alpha2",
 			"kind": "TrafficSplit",
 			"metadata": {
-				"name": "testservice-rollout"
+				"name": "testservice-trafficsplit"
 			},
 			"spec": {
 				"service": "testservice",
@@ -602,14 +602,14 @@ test("shouldWePromoteSMI - throws if trafficsplit in wrong state", () => {
 	expect(blueGreenHelperSMI.validateTrafficSplitState(kubeCtl, depEntList, serEntList)).toBeFalsy();
 });
 
-test("shouldWePromoteSMI - throws if trafficsplit in wrong state", () => {
+test("validateTrafficSplitState - throws if trafficsplit in wrong state", () => {
 	const kubeCtl: jest.Mocked < Kubectl > = new Kubectl("") as any;
 	let temp = {
 		stdout: JSON.stringify({
 			"apiVersion": "split.smi-spec.io/v1alpha2",
 			"kind": "TrafficSplit",
 			"metadata": {
-				"name": "testservice-rollout"
+				"name": "testservice-trafficsplit"
 			},
 			"spec": {
 				"service": "testservice",
@@ -678,7 +678,6 @@ test("shouldWePromoteSMI - throws if trafficsplit in wrong state", () => {
 	kubeCtl.getResource = jest.fn().mockReturnValue(JSON.parse(JSON.stringify(temp)));
 
 	//Invoke and assert
-	const thr = () => 
 	expect(blueGreenHelperSMI.validateTrafficSplitState(kubeCtl, depEntList, serEntList)).toBeFalsy();
 });
 

--- a/__tests__/blue-green-helper.test.ts
+++ b/__tests__/blue-green-helper.test.ts
@@ -35,7 +35,7 @@ test("deployBlueGreen - checks if deployment can be done, then deploys", () => {
 	const readFileSpy = jest.spyOn(fs, 'readFileSync').mockImplementation(() => deploymentYaml);
 
 	//Invoke and assert
-	expect(blueGreenHelperService.deployBlueGreen(kubeCtl, ['manifests/bg.yaml'])).toMatchObject({
+	expect(blueGreenHelperService.deployBlueGreenService(kubeCtl, ['manifests/bg.yaml'])).toMatchObject({
 		"newFilePaths": "hello",
 		"result": ""
 	});
@@ -157,12 +157,12 @@ test("blueGreenReject - deletes services if old deployment does not exist", () =
 
 test("isIngressRoute() - returns true if route-method is ingress", () => {
 	// default is service
-	expect(blueGreenHelperIngress.isIngressRoute()).toBeFalsy();
+	expect(blueGreenHelper.isIngressRoute()).toBeFalsy();
 });
 
 test("isIngressRoute() - returns true if route-method is ingress", () => {
 	inputParamMock.routeMethod = 'ingress'
-	expect(blueGreenHelperIngress.isIngressRoute()).toBeTruthy();
+	expect(blueGreenHelper.isIngressRoute()).toBeTruthy();
 });
 
 test("deployBlueGreenIngress - creates deployments, services and other non ingress objects", () => {
@@ -246,12 +246,12 @@ test("blueGreenRejectIngress - routes ingress to stable services and deletes new
 
 test("isSMIRoute() - returns true if route-method is smi", () => {
 	inputParamMock.routeMethod = 'smi'
-	expect(blueGreenHelperSMI.isSMIRoute()).toBeTruthy();
+	expect(blueGreenHelper.isSMIRoute()).toBeTruthy();
 });
 
 test("isSMIRoute() - returns true if route-method is smi", () => {
 	inputParamMock.routeMethod = 'ingress'
-	expect(blueGreenHelperSMI.isSMIRoute()).toBeFalsy();
+	expect(blueGreenHelper.isSMIRoute()).toBeFalsy();
 });
 
 test("deployBlueGreenSMI - checks if deployment can be done, then deploys along this auxiliary services and trafficsplit", () => {
@@ -478,7 +478,7 @@ test("blueGreenRouteIngress - routes to green services in nextlabel is green", (
 	kubeCtl.apply = jest.fn().mockReturnValue('');
 
 	//Invoke and assert
-	expect(blueGreenHelperIngress.blueGreenRouteIngress(kubeCtl, 'green', serviceEntityMap, serEntList, ingEntList));
+	expect(blueGreenHelperIngress.routeBlueGreenIngress(kubeCtl, 'green', serviceEntityMap, serEntList, ingEntList));
 	expect(kubeCtl.apply).toBeCalled();
 	expect(fileHelperMock.writeObjectsToFile).toBeCalled();
 });

--- a/__tests__/blue-green-helper.test.ts
+++ b/__tests__/blue-green-helper.test.ts
@@ -127,7 +127,7 @@ test("blueGreenReject - routes servcies to old deployment and deletes new deploy
 	const readFileSpy = jest.spyOn(fs, 'readFileSync').mockImplementation(() => deploymentYaml);
 
 	//Invoke and assert
-	expect(blueGreenHelperService.blueGreenReject(kubeCtl, ['manifests/bg.yaml'])).toMatchObject({});
+	expect(blueGreenHelperService.rejectBlueGreenService(kubeCtl, ['manifests/bg.yaml'])).toMatchObject({});
 	expect(kubeCtl.delete).toBeCalledWith(["Deployment", "testapp-green"]);
 	expect(readFileSpy).toBeCalledWith("manifests/bg.yaml");
 	expect(fileHelperMock.writeObjectsToFile).toBeCalled();
@@ -147,7 +147,7 @@ test("blueGreenReject - deletes services if old deployment does not exist", () =
 	const readFileSpy = jest.spyOn(fs, 'readFileSync').mockImplementation(() => deploymentYaml);
 
 	//Invoke and assert
-	expect(blueGreenHelperService.blueGreenReject(kubeCtl, ['manifests/bg.yaml'])).toMatchObject({});
+	expect(blueGreenHelperService.rejectBlueGreenService(kubeCtl, ['manifests/bg.yaml'])).toMatchObject({});
 	expect(kubeCtl.delete).toBeCalledWith(["Deployment", "testapp-green"]);
 	expect(kubeCtl.delete).toBeCalledWith(["Service", "testservice"]);
 	expect(readFileSpy).toBeCalledWith("manifests/bg.yaml");
@@ -237,7 +237,7 @@ test("blueGreenRejectIngress - routes ingress to stable services and deletes new
 	const readFileSpy = jest.spyOn(fs, 'readFileSync').mockImplementation(() => deploymentYaml);
 
 	//Invoke and assert
-	expect(blueGreenHelperIngress.blueGreenRejectIngress(kubeCtl, ['manifests/bg.yaml'])).toMatchObject({});
+	expect(blueGreenHelperIngress.rejectBlueGreenIngress(kubeCtl, ['manifests/bg.yaml'])).toMatchObject({});
 	expect(kubeCtl.delete).toBeCalledWith(["Deployment", "testapp-green"]);
 	expect(kubeCtl.delete).toBeCalledWith(["Service", "testservice-green"]);
 	expect(readFileSpy).toBeCalledWith("manifests/bg.yaml");
@@ -359,7 +359,7 @@ test("blueGreenRejectSMI - routes servcies to old deployment and deletes new dep
 	const readFileSpy = jest.spyOn(fs, 'readFileSync').mockImplementation(() => deploymentYaml);
 
 	//Invoke and assert
-	expect(blueGreenHelperSMI.blueGreenRejectSMI(kubeCtl, ['manifests/bg.yaml'])).toMatchObject({});
+	expect(blueGreenHelperSMI.rejectBlueGreenSMI(kubeCtl, ['manifests/bg.yaml'])).toMatchObject({});
 	expect(kubeCtl.delete).toBeCalledWith(["Deployment", "testapp-green"]);
 	expect(kubeCtl.delete).toBeCalledWith(["Service", "testservice-green"]);
 	expect(kubeCtl.delete).toBeCalledWith(["Service", "testservice-stable"]);
@@ -381,7 +381,7 @@ test("blueGreenRejectSMI - deletes service if stable deployment doesn't exist", 
 	const readFileSpy = jest.spyOn(fs, 'readFileSync').mockImplementation(() => deploymentYaml);
 
 	//Invoke and assert
-	expect(blueGreenHelperSMI.blueGreenRejectSMI(kubeCtl, ['manifests/bg.yaml'])).toMatchObject({});
+	expect(blueGreenHelperSMI.rejectBlueGreenSMI(kubeCtl, ['manifests/bg.yaml'])).toMatchObject({});
 	expect(kubeCtl.delete).toBeCalledWith(["Deployment", "testapp-green"]);
 	expect(kubeCtl.delete).toBeCalledWith(["Service", "testservice"]);
 	expect(kubeCtl.delete).toBeCalledWith(["Service", "testservice-green"]);

--- a/__tests__/blue-green-helper.test.ts
+++ b/__tests__/blue-green-helper.test.ts
@@ -599,7 +599,7 @@ test("validateTrafficSplitState - throws if trafficsplit in wrong state", () => 
 	kubeCtl.getResource = jest.fn().mockReturnValue(JSON.parse(JSON.stringify(temp)));
 
 	//Invoke and assert
-	expect(blueGreenHelperSMI.validateTrafficSplitState(kubeCtl, depEntList, serEntList)).toBeFalsy();
+	expect(blueGreenHelperSMI.validateTrafficSplitsState(kubeCtl, depEntList, serEntList)).toBeFalsy();
 });
 
 test("validateTrafficSplitState - throws if trafficsplit in wrong state", () => {
@@ -678,7 +678,7 @@ test("validateTrafficSplitState - throws if trafficsplit in wrong state", () => 
 	kubeCtl.getResource = jest.fn().mockReturnValue(JSON.parse(JSON.stringify(temp)));
 
 	//Invoke and assert
-	expect(blueGreenHelperSMI.validateTrafficSplitState(kubeCtl, depEntList, serEntList)).toBeFalsy();
+	expect(blueGreenHelperSMI.validateTrafficSplitsState(kubeCtl, depEntList, serEntList)).toBeFalsy();
 });
 
 test("getSuffix() - returns BLUE_GREEN_SUFFIX if BLUE_GREEN_NEW_LABEL_VALUE is given, else emrty string", () => {

--- a/__tests__/manifests/bg-smi.yml
+++ b/__tests__/manifests/bg-smi.yml
@@ -1,0 +1,32 @@
+apiVersion : apps/v1beta1
+kind: Deployment
+metadata:
+  name: testapp 
+spec:
+  selector:
+    matchLabels:
+      app: testapp
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: testapp 
+    spec:
+      containers:
+        - name: testapp 
+          image: testcr.azurecr.io/testapp
+          ports:
+          - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: testservice
+spec:
+  selector:
+    app: testapp
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+---

--- a/__tests__/manifests/bg.yml
+++ b/__tests__/manifests/bg.yml
@@ -1,0 +1,85 @@
+apiVersion : apps/v1beta1
+kind: Deployment
+metadata:
+  name: testapp 
+spec:
+  selector:
+    matchLabels:
+      app: testapp
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: testapp 
+    spec:
+      containers:
+        - name: testapp 
+          image: testcr.azurecr.io/testapp
+          ports:
+          - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: testservice
+spec:
+  selector:
+    app: testapp
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+---
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: testingress
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /testpath
+        pathType: Prefix
+        backend:
+          serviceName: testservice
+          servicePort: 80
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: testconfigmap
+data:
+  # property-like keys; each key maps to a simple value
+  whats_this: "testing"
+  why_this: "testing"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: testservice-2
+spec:
+  selector:
+    app: testapp-2
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+---
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: testingress-1
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /testpath
+        pathType: Prefix
+        backend:
+          serviceName: testnotservice
+          servicePort: 80
+---

--- a/action.yml
+++ b/action.yml
@@ -19,9 +19,17 @@ inputs:
       description: 'Version of kubectl. Installs a specific version of kubectl binary'
       required: false
   strategy:
-    description: 'Deployment strategy to be used. Allowed values are none, canary'
+    description: 'Deployment strategy to be used. Allowed values are none, canary and blue-green'
     required: false
     default: 'none'
+  route-method:
+    description: 'Route based on service, ingress or SMI for blue-green strategy'
+    required: false
+    default: 'service'
+  version-switch-buffer:
+    description: 'Indicates the buffer time in minutes before the switch is made to the green version (max is 300 min ie. 5hrs)'
+    required: false
+    default: 0
   traffic-split-method:
     description: "Traffic split method to be used. Allowed values are pod, smi"
     required: false

--- a/lib/actions/promote.js
+++ b/lib/actions/promote.js
@@ -1,9 +1,10 @@
 'use strict';
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
         function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
@@ -15,14 +16,34 @@ const canaryDeploymentHelper = require("../utilities/strategy-helpers/canary-dep
 const SMICanaryDeploymentHelper = require("../utilities/strategy-helpers/smi-canary-deployment-helper");
 const utils = require("../utilities/manifest-utilities");
 const TaskInputParameters = require("../input-parameters");
+const manifest_utilities_1 = require("../utilities/manifest-utilities");
+const KubernetesObjectUtility = require("../utilities/resource-object-utility");
+const models = require("../constants");
+const KubernetesManifestUtility = require("../utilities/manifest-stability-utility");
+const blue_green_helper_1 = require("../utilities/strategy-helpers/blue-green-helper");
+const blue_green_helper_2 = require("../utilities/strategy-helpers/blue-green-helper");
+const service_blue_green_helper_1 = require("../utilities/strategy-helpers/service-blue-green-helper");
+const ingress_blue_green_helper_1 = require("../utilities/strategy-helpers/ingress-blue-green-helper");
+const smi_blue_green_helper_1 = require("../utilities/strategy-helpers/smi-blue-green-helper");
 const kubectl_object_model_1 = require("../kubectl-object-model");
-function promote(ignoreSslErrors) {
+function promote() {
     return __awaiter(this, void 0, void 0, function* () {
-        const kubectl = new kubectl_object_model_1.Kubectl(yield utils.getKubectl(), TaskInputParameters.namespace, ignoreSslErrors);
-        if (!canaryDeploymentHelper.isCanaryDeploymentStrategy()) {
-            core.debug('Strategy is not canary deployment. Invalid request.');
+        const kubectl = new kubectl_object_model_1.Kubectl(yield utils.getKubectl(), TaskInputParameters.namespace, true);
+        if (canaryDeploymentHelper.isCanaryDeploymentStrategy()) {
+            yield promoteCanary(kubectl);
+        }
+        else if (service_blue_green_helper_1.isBlueGreenDeploymentStrategy()) {
+            yield promoteBlueGreen(kubectl);
+        }
+        else {
+            core.debug('Strategy is not canary or blue-green deployment. Invalid request.');
             throw ('InvalidPromotetActionDeploymentStrategy');
         }
+    });
+}
+exports.promote = promote;
+function promoteCanary(kubectl) {
+    return __awaiter(this, void 0, void 0, function* () {
         let includeServices = false;
         if (canaryDeploymentHelper.isSMICanaryStrategy()) {
             includeServices = true;
@@ -48,4 +69,40 @@ function promote(ignoreSslErrors) {
         }
     });
 }
-exports.promote = promote;
+function promoteBlueGreen(kubectl) {
+    return __awaiter(this, void 0, void 0, function* () {
+        // updated container images and pull secrets
+        let inputManifestFiles = manifest_utilities_1.getUpdatedManifestFiles(TaskInputParameters.manifests);
+        const manifestObjects = blue_green_helper_1.getManifestObjects(inputManifestFiles);
+        core.debug('deleting old deployment and making new ones');
+        let result;
+        if (ingress_blue_green_helper_1.isIngressRoute()) {
+            result = yield ingress_blue_green_helper_1.blueGreenPromoteIngress(kubectl, manifestObjects);
+        }
+        else if (smi_blue_green_helper_1.isSMIRoute()) {
+            result = yield smi_blue_green_helper_1.blueGreenPromoteSMI(kubectl, manifestObjects);
+        }
+        else {
+            result = yield service_blue_green_helper_1.blueGreenPromote(kubectl, manifestObjects);
+        }
+        // checking stability of newly created deployments 
+        const deployedManifestFiles = result.newFilePaths;
+        const resourceTypes = KubernetesObjectUtility.getResources(deployedManifestFiles, models.deploymentTypes.concat([models.DiscoveryAndLoadBalancerResource.service]));
+        yield KubernetesManifestUtility.checkManifestStability(kubectl, resourceTypes);
+        core.debug('routing to new deployments');
+        yield KubernetesManifestUtility.checkManifestStability(kubectl, resourceTypes);
+        if (ingress_blue_green_helper_1.isIngressRoute()) {
+            ingress_blue_green_helper_1.blueGreenRouteIngress(kubectl, null, manifestObjects.serviceNameMap, manifestObjects.serviceEntityList, manifestObjects.ingressEntityList);
+            blue_green_helper_1.deleteWorkloadsAndServicesWithLabel(kubectl, blue_green_helper_2.BLUE_GREEN_NEW_LABEL_VALUE, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
+        }
+        else if (smi_blue_green_helper_1.isSMIRoute()) {
+            smi_blue_green_helper_1.blueGreenRouteTraffic(kubectl, blue_green_helper_2.NONE_LABEL_VALUE, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
+            blue_green_helper_1.deleteWorkloadsWithLabel(kubectl, blue_green_helper_2.BLUE_GREEN_NEW_LABEL_VALUE, manifestObjects.deploymentEntityList);
+            smi_blue_green_helper_1.cleanSetUpSMI(kubectl, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
+        }
+        else {
+            service_blue_green_helper_1.blueGreenRouteService(kubectl, blue_green_helper_2.NONE_LABEL_VALUE, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
+            blue_green_helper_1.deleteWorkloadsWithLabel(kubectl, blue_green_helper_2.BLUE_GREEN_NEW_LABEL_VALUE, manifestObjects.deploymentEntityList);
+        }
+    });
+}

--- a/lib/actions/promote.js
+++ b/lib/actions/promote.js
@@ -32,7 +32,7 @@ function promote() {
         if (canaryDeploymentHelper.isCanaryDeploymentStrategy()) {
             yield promoteCanary(kubectl);
         }
-        else if (service_blue_green_helper_1.isBlueGreenDeploymentStrategy()) {
+        else if (blue_green_helper_2.isBlueGreenDeploymentStrategy()) {
             yield promoteBlueGreen(kubectl);
         }
         else {
@@ -76,10 +76,10 @@ function promoteBlueGreen(kubectl) {
         const manifestObjects = blue_green_helper_1.getManifestObjects(inputManifestFiles);
         core.debug('deleting old deployment and making new ones');
         let result;
-        if (ingress_blue_green_helper_1.isIngressRoute()) {
+        if (blue_green_helper_2.isIngressRoute()) {
             result = yield ingress_blue_green_helper_1.blueGreenPromoteIngress(kubectl, manifestObjects);
         }
-        else if (smi_blue_green_helper_1.isSMIRoute()) {
+        else if (blue_green_helper_2.isSMIRoute()) {
             result = yield smi_blue_green_helper_1.blueGreenPromoteSMI(kubectl, manifestObjects);
         }
         else {
@@ -91,17 +91,17 @@ function promoteBlueGreen(kubectl) {
         yield KubernetesManifestUtility.checkManifestStability(kubectl, resourceTypes);
         core.debug('routing to new deployments');
         yield KubernetesManifestUtility.checkManifestStability(kubectl, resourceTypes);
-        if (ingress_blue_green_helper_1.isIngressRoute()) {
-            ingress_blue_green_helper_1.blueGreenRouteIngress(kubectl, null, manifestObjects.serviceNameMap, manifestObjects.serviceEntityList, manifestObjects.ingressEntityList);
+        if (blue_green_helper_2.isIngressRoute()) {
+            ingress_blue_green_helper_1.routeBlueGreenIngress(kubectl, null, manifestObjects.serviceNameMap, manifestObjects.serviceEntityList, manifestObjects.ingressEntityList);
             blue_green_helper_1.deleteWorkloadsAndServicesWithLabel(kubectl, blue_green_helper_2.BLUE_GREEN_NEW_LABEL_VALUE, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
         }
-        else if (smi_blue_green_helper_1.isSMIRoute()) {
-            smi_blue_green_helper_1.blueGreenRouteTraffic(kubectl, blue_green_helper_2.NONE_LABEL_VALUE, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
+        else if (blue_green_helper_2.isSMIRoute()) {
+            smi_blue_green_helper_1.routeBlueGreenSMI(kubectl, blue_green_helper_2.NONE_LABEL_VALUE, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
             blue_green_helper_1.deleteWorkloadsWithLabel(kubectl, blue_green_helper_2.BLUE_GREEN_NEW_LABEL_VALUE, manifestObjects.deploymentEntityList);
-            smi_blue_green_helper_1.cleanSetUpSMI(kubectl, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
+            smi_blue_green_helper_1.cleanupSMI(kubectl, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
         }
         else {
-            service_blue_green_helper_1.blueGreenRouteService(kubectl, blue_green_helper_2.NONE_LABEL_VALUE, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
+            service_blue_green_helper_1.routeBlueGreenService(kubectl, blue_green_helper_2.NONE_LABEL_VALUE, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
             blue_green_helper_1.deleteWorkloadsWithLabel(kubectl, blue_green_helper_2.BLUE_GREEN_NEW_LABEL_VALUE, manifestObjects.deploymentEntityList);
         }
     });

--- a/lib/actions/promote.js
+++ b/lib/actions/promote.js
@@ -77,32 +77,31 @@ function promoteBlueGreen(kubectl) {
         core.debug('deleting old deployment and making new ones');
         let result;
         if (blue_green_helper_2.isIngressRoute()) {
-            result = yield ingress_blue_green_helper_1.blueGreenPromoteIngress(kubectl, manifestObjects);
+            result = yield ingress_blue_green_helper_1.promoteBlueGreenIngress(kubectl, manifestObjects);
         }
         else if (blue_green_helper_2.isSMIRoute()) {
-            result = yield smi_blue_green_helper_1.blueGreenPromoteSMI(kubectl, manifestObjects);
+            result = yield smi_blue_green_helper_1.promoteBlueGreenSMI(kubectl, manifestObjects);
         }
         else {
-            result = yield service_blue_green_helper_1.blueGreenPromote(kubectl, manifestObjects);
+            result = yield service_blue_green_helper_1.promoteBlueGreenService(kubectl, manifestObjects);
         }
         // checking stability of newly created deployments 
         const deployedManifestFiles = result.newFilePaths;
-        const resourceTypes = KubernetesObjectUtility.getResources(deployedManifestFiles, models.deploymentTypes.concat([models.DiscoveryAndLoadBalancerResource.service]));
-        yield KubernetesManifestUtility.checkManifestStability(kubectl, resourceTypes);
+        const resources = KubernetesObjectUtility.getResources(deployedManifestFiles, models.deploymentTypes.concat([models.DiscoveryAndLoadBalancerResource.service]));
+        yield KubernetesManifestUtility.checkManifestStability(kubectl, resources);
         core.debug('routing to new deployments');
-        yield KubernetesManifestUtility.checkManifestStability(kubectl, resourceTypes);
         if (blue_green_helper_2.isIngressRoute()) {
             ingress_blue_green_helper_1.routeBlueGreenIngress(kubectl, null, manifestObjects.serviceNameMap, manifestObjects.serviceEntityList, manifestObjects.ingressEntityList);
-            blue_green_helper_1.deleteWorkloadsAndServicesWithLabel(kubectl, blue_green_helper_2.BLUE_GREEN_NEW_LABEL_VALUE, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
+            blue_green_helper_1.deleteWorkloadsAndServicesWithLabel(kubectl, blue_green_helper_2.GREEN_LABEL_VALUE, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
         }
         else if (blue_green_helper_2.isSMIRoute()) {
             smi_blue_green_helper_1.routeBlueGreenSMI(kubectl, blue_green_helper_2.NONE_LABEL_VALUE, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
-            blue_green_helper_1.deleteWorkloadsWithLabel(kubectl, blue_green_helper_2.BLUE_GREEN_NEW_LABEL_VALUE, manifestObjects.deploymentEntityList);
+            blue_green_helper_1.deleteWorkloadsWithLabel(kubectl, blue_green_helper_2.GREEN_LABEL_VALUE, manifestObjects.deploymentEntityList);
             smi_blue_green_helper_1.cleanupSMI(kubectl, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
         }
         else {
             service_blue_green_helper_1.routeBlueGreenService(kubectl, blue_green_helper_2.NONE_LABEL_VALUE, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
-            blue_green_helper_1.deleteWorkloadsWithLabel(kubectl, blue_green_helper_2.BLUE_GREEN_NEW_LABEL_VALUE, manifestObjects.deploymentEntityList);
+            blue_green_helper_1.deleteWorkloadsWithLabel(kubectl, blue_green_helper_2.GREEN_LABEL_VALUE, manifestObjects.deploymentEntityList);
         }
     });
 }

--- a/lib/actions/reject.js
+++ b/lib/actions/reject.js
@@ -19,6 +19,7 @@ const TaskInputParameters = require("../input-parameters");
 const service_blue_green_helper_1 = require("../utilities/strategy-helpers/service-blue-green-helper");
 const ingress_blue_green_helper_1 = require("../utilities/strategy-helpers/ingress-blue-green-helper");
 const smi_blue_green_helper_1 = require("../utilities/strategy-helpers/smi-blue-green-helper");
+const blue_green_helper_1 = require("../utilities/strategy-helpers/blue-green-helper");
 const deployment_helper_1 = require("../utilities/strategy-helpers/deployment-helper");
 function reject() {
     return __awaiter(this, void 0, void 0, function* () {
@@ -26,7 +27,7 @@ function reject() {
         if (canaryDeploymentHelper.isCanaryDeploymentStrategy()) {
             yield rejectCanary(kubectl);
         }
-        else if (service_blue_green_helper_1.isBlueGreenDeploymentStrategy()) {
+        else if (blue_green_helper_1.isBlueGreenDeploymentStrategy()) {
             yield rejectBlueGreen(kubectl);
         }
         else {
@@ -51,10 +52,10 @@ function rejectCanary(kubectl) {
 function rejectBlueGreen(kubectl) {
     return __awaiter(this, void 0, void 0, function* () {
         let inputManifestFiles = deployment_helper_1.getManifestFiles(TaskInputParameters.manifests);
-        if (ingress_blue_green_helper_1.isIngressRoute()) {
+        if (blue_green_helper_1.isIngressRoute()) {
             yield ingress_blue_green_helper_1.blueGreenRejectIngress(kubectl, inputManifestFiles);
         }
-        else if (smi_blue_green_helper_1.isSMIRoute()) {
+        else if (blue_green_helper_1.isSMIRoute()) {
             yield smi_blue_green_helper_1.blueGreenRejectSMI(kubectl, inputManifestFiles);
         }
         else {

--- a/lib/actions/reject.js
+++ b/lib/actions/reject.js
@@ -1,9 +1,10 @@
 'use strict';
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
         function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
@@ -15,13 +16,28 @@ const SMICanaryDeploymentHelper = require("../utilities/strategy-helpers/smi-can
 const kubectl_object_model_1 = require("../kubectl-object-model");
 const utils = require("../utilities/manifest-utilities");
 const TaskInputParameters = require("../input-parameters");
-function reject(ignoreSslErrors) {
+const service_blue_green_helper_1 = require("../utilities/strategy-helpers/service-blue-green-helper");
+const ingress_blue_green_helper_1 = require("../utilities/strategy-helpers/ingress-blue-green-helper");
+const smi_blue_green_helper_1 = require("../utilities/strategy-helpers/smi-blue-green-helper");
+const deployment_helper_1 = require("../utilities/strategy-helpers/deployment-helper");
+function reject() {
     return __awaiter(this, void 0, void 0, function* () {
-        const kubectl = new kubectl_object_model_1.Kubectl(yield utils.getKubectl(), TaskInputParameters.namespace, ignoreSslErrors);
-        if (!canaryDeploymentHelper.isCanaryDeploymentStrategy()) {
-            core.debug('Strategy is not canary deployment. Invalid request.');
-            throw ('InvalidRejectActionDeploymentStrategy');
+        const kubectl = new kubectl_object_model_1.Kubectl(yield utils.getKubectl(), TaskInputParameters.namespace, true);
+        if (canaryDeploymentHelper.isCanaryDeploymentStrategy()) {
+            yield rejectCanary(kubectl);
         }
+        else if (service_blue_green_helper_1.isBlueGreenDeploymentStrategy()) {
+            yield rejectBlueGreen(kubectl);
+        }
+        else {
+            core.debug('Strategy is not canary or blue-green deployment. Invalid request.');
+            throw ('InvalidDeletetActionDeploymentStrategy');
+        }
+    });
+}
+exports.reject = reject;
+function rejectCanary(kubectl) {
+    return __awaiter(this, void 0, void 0, function* () {
         let includeServices = false;
         if (canaryDeploymentHelper.isSMICanaryStrategy()) {
             core.debug('Reject deployment with SMI canary strategy');
@@ -32,4 +48,17 @@ function reject(ignoreSslErrors) {
         canaryDeploymentHelper.deleteCanaryDeployment(kubectl, TaskInputParameters.manifests, includeServices);
     });
 }
-exports.reject = reject;
+function rejectBlueGreen(kubectl) {
+    return __awaiter(this, void 0, void 0, function* () {
+        let inputManifestFiles = deployment_helper_1.getManifestFiles(TaskInputParameters.manifests);
+        if (ingress_blue_green_helper_1.isIngressRoute()) {
+            yield ingress_blue_green_helper_1.blueGreenRejectIngress(kubectl, inputManifestFiles);
+        }
+        else if (smi_blue_green_helper_1.isSMIRoute()) {
+            yield smi_blue_green_helper_1.blueGreenRejectSMI(kubectl, inputManifestFiles);
+        }
+        else {
+            yield service_blue_green_helper_1.blueGreenReject(kubectl, inputManifestFiles);
+        }
+    });
+}

--- a/lib/actions/reject.js
+++ b/lib/actions/reject.js
@@ -53,13 +53,13 @@ function rejectBlueGreen(kubectl) {
     return __awaiter(this, void 0, void 0, function* () {
         let inputManifestFiles = deployment_helper_1.getManifestFiles(TaskInputParameters.manifests);
         if (blue_green_helper_1.isIngressRoute()) {
-            yield ingress_blue_green_helper_1.blueGreenRejectIngress(kubectl, inputManifestFiles);
+            yield ingress_blue_green_helper_1.rejectBlueGreenIngress(kubectl, inputManifestFiles);
         }
         else if (blue_green_helper_1.isSMIRoute()) {
-            yield smi_blue_green_helper_1.blueGreenRejectSMI(kubectl, inputManifestFiles);
+            yield smi_blue_green_helper_1.rejectBlueGreenSMI(kubectl, inputManifestFiles);
         }
         else {
-            yield service_blue_green_helper_1.blueGreenReject(kubectl, inputManifestFiles);
+            yield service_blue_green_helper_1.rejectBlueGreenService(kubectl, inputManifestFiles);
         }
     });
 }

--- a/lib/input-parameters.js
+++ b/lib/input-parameters.js
@@ -1,6 +1,6 @@
 'use strict';
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.forceDeployment = exports.args = exports.baselineAndCanaryReplicas = exports.trafficSplitMethod = exports.deploymentStrategy = exports.canaryPercentage = exports.manifests = exports.imagePullSecrets = exports.containers = exports.namespace = void 0;
+exports.forceDeployment = exports.args = exports.baselineAndCanaryReplicas = exports.versionSwitchBuffer = exports.routeMethod = exports.trafficSplitMethod = exports.deploymentStrategy = exports.canaryPercentage = exports.manifests = exports.imagePullSecrets = exports.containers = exports.namespace = void 0;
 const core = require("@actions/core");
 exports.namespace = core.getInput('namespace');
 exports.containers = core.getInput('images').split('\n');
@@ -9,6 +9,8 @@ exports.manifests = core.getInput('manifests').split('\n');
 exports.canaryPercentage = core.getInput('percentage');
 exports.deploymentStrategy = core.getInput('strategy');
 exports.trafficSplitMethod = core.getInput('traffic-split-method');
+exports.routeMethod = core.getInput('route-method');
+exports.versionSwitchBuffer = core.getInput('version-switch-buffer');
 exports.baselineAndCanaryReplicas = core.getInput('baseline-and-canary-replicas');
 exports.args = core.getInput('arguments');
 exports.forceDeployment = core.getInput('force').toLowerCase() == 'true';
@@ -36,5 +38,16 @@ try {
 }
 catch (ex) {
     core.setFailed("Enter a valid 'baseline-and-canary-replicas' integer value");
+    process.exit(1);
+}
+try {
+    const pe = parseInt(exports.versionSwitchBuffer);
+    if (pe < 0 || pe > 300) {
+        core.setFailed('Invalid buffer time, valid version-switch-buffer is a value more than or equal to 0 and lesser than or equal 300');
+        process.exit(1);
+    }
+}
+catch (ex) {
+    core.setFailed("Enter a valid 'version-switch-buffer' integer value");
     process.exit(1);
 }

--- a/lib/run.js
+++ b/lib/run.js
@@ -77,10 +77,10 @@ function run() {
             yield deployment_helper_1.deploy(new kubectl_object_model_1.Kubectl(kubectlPath, namespace), manifests, strategy);
         }
         else if (action === 'promote') {
-            yield promote_1.promote(true);
+            yield promote_1.promote();
         }
         else if (action === 'reject') {
-            yield reject_1.reject(true);
+            yield reject_1.reject();
         }
         else {
             core.setFailed('Not a valid action. The allowed actions are deploy, promote, reject');

--- a/lib/utilities/manifest-utilities.js
+++ b/lib/utilities/manifest-utilities.js
@@ -9,11 +9,17 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.isWorkloadEntity = exports.updateImagePullSecrets = exports.updateContainerImagesInManifestFiles = exports.substituteImageNameInSpecFile = exports.getDeleteCmdArgs = exports.createKubectlArgs = exports.getKubectl = exports.getManifestFiles = void 0;
+exports.isWorkloadEntity = exports.getUpdatedManifestFiles = exports.updateImagePullSecrets = exports.substituteImageNameInSpecFile = exports.getDeleteCmdArgs = exports.createKubectlArgs = exports.getKubectl = exports.getManifestFiles = void 0;
 const core = require("@actions/core");
+const fs = require("fs");
+const yaml = require("js-yaml");
+const path = require("path");
 const kubectlutility = require("./kubectl-util");
 const io = require("@actions/io");
 const utility_1 = require("./utility");
+const fileHelper = require("./files-helper");
+const KubernetesObjectUtility = require("./resource-object-utility");
+const TaskInputParameters = require("../input-parameters");
 function getManifestFiles(manifestFilePaths) {
     if (!manifestFilePaths) {
         core.debug('file input is not present');
@@ -189,21 +195,29 @@ function substituteImageNameInSpecContent(currentString, imageName, imageNameWit
         return acc + line + '\n';
     }, '');
 }
-function updateContainerImagesInManifestFiles(contents, containers) {
+function updateContainerImagesInManifestFiles(filePaths, containers) {
     if (!!containers && containers.length > 0) {
-        containers.forEach((container) => {
-            let imageName = container.split(':')[0];
-            if (imageName.indexOf('@') > 0) {
-                imageName = imageName.split('@')[0];
-            }
-            if (contents.indexOf(imageName) > 0) {
-                contents = substituteImageNameInSpecContent(contents, imageName, container);
-            }
+        const newFilePaths = [];
+        const tempDirectory = fileHelper.getTempDirectory();
+        filePaths.forEach((filePath) => {
+            let contents = fs.readFileSync(filePath).toString();
+            containers.forEach((container) => {
+                let imageName = container.split(':')[0];
+                if (imageName.indexOf('@') > 0) {
+                    imageName = imageName.split('@')[0];
+                }
+                if (contents.indexOf(imageName) > 0) {
+                    contents = substituteImageNameInSpecFile(contents, imageName, container);
+                }
+            });
+            const fileName = path.join(tempDirectory, path.basename(filePath));
+            fs.writeFileSync(path.join(fileName), contents);
+            newFilePaths.push(fileName);
         });
+        return newFilePaths;
     }
-    return contents;
+    return filePaths;
 }
-exports.updateContainerImagesInManifestFiles = updateContainerImagesInManifestFiles;
 function updateImagePullSecrets(inputObject, newImagePullSecrets) {
     if (!inputObject || !inputObject.spec || !newImagePullSecrets) {
         return;
@@ -223,6 +237,39 @@ function updateImagePullSecrets(inputObject, newImagePullSecrets) {
     setImagePullSecrets(inputObject, existingImagePullSecretObjects);
 }
 exports.updateImagePullSecrets = updateImagePullSecrets;
+function updateImagePullSecretsInManifestFiles(filePaths, imagePullSecrets) {
+    if (!!imagePullSecrets && imagePullSecrets.length > 0) {
+        const newObjectsList = [];
+        filePaths.forEach((filePath) => {
+            const fileContents = fs.readFileSync(filePath).toString();
+            yaml.safeLoadAll(fileContents, function (inputObject) {
+                if (!!inputObject && !!inputObject.kind) {
+                    const kind = inputObject.kind;
+                    if (KubernetesObjectUtility.isWorkloadEntity(kind)) {
+                        KubernetesObjectUtility.updateImagePullSecrets(inputObject, imagePullSecrets, false);
+                    }
+                    newObjectsList.push(inputObject);
+                }
+            });
+        });
+        core.debug('New K8s objects after addin imagePullSecrets are :' + JSON.stringify(newObjectsList));
+        const newFilePaths = fileHelper.writeObjectsToFile(newObjectsList);
+        return newFilePaths;
+    }
+    return filePaths;
+}
+function getUpdatedManifestFiles(manifestFilePaths) {
+    let inputManifestFiles = getManifestFiles(manifestFilePaths);
+    if (!inputManifestFiles || inputManifestFiles.length === 0) {
+        throw new Error(`ManifestFileNotFound : ${manifestFilePaths}`);
+    }
+    // artifact substitution
+    inputManifestFiles = updateContainerImagesInManifestFiles(inputManifestFiles, TaskInputParameters.containers);
+    // imagePullSecrets addition
+    inputManifestFiles = updateImagePullSecretsInManifestFiles(inputManifestFiles, TaskInputParameters.imagePullSecrets);
+    return inputManifestFiles;
+}
+exports.getUpdatedManifestFiles = getUpdatedManifestFiles;
 const workloadTypes = ['deployment', 'replicaset', 'daemonset', 'pod', 'statefulset', 'job', 'cronjob'];
 function isWorkloadEntity(kind) {
     if (!kind) {

--- a/lib/utilities/resource-object-utility.js
+++ b/lib/utilities/resource-object-utility.js
@@ -6,6 +6,7 @@ const core = require("@actions/core");
 const yaml = require("js-yaml");
 const constants_1 = require("../constants");
 const string_comparison_1 = require("./string-comparison");
+const INGRESS = "Ingress";
 function isDeploymentEntity(kind) {
     if (!kind) {
         throw ('ResourceKindNotDefined');
@@ -35,7 +36,7 @@ function isIngressEntity(kind) {
     if (!kind) {
         throw ('ResourceKindNotDefined');
     }
-    return string_comparison_1.isEqual("Ingress", kind, string_comparison_1.StringComparer.OrdinalIgnoreCase);
+    return string_comparison_1.isEqual(INGRESS, kind, string_comparison_1.StringComparer.OrdinalIgnoreCase);
 }
 exports.isIngressEntity = isIngressEntity;
 function getReplicaCount(inputObject) {

--- a/lib/utilities/resource-object-utility.js
+++ b/lib/utilities/resource-object-utility.js
@@ -1,6 +1,6 @@
 'use strict';
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.getResources = exports.updateSelectorLabels = exports.updateSpecLabels = exports.updateImageDetails = exports.updateImagePullSecrets = exports.updateObjectLabels = exports.getReplicaCount = exports.isServiceEntity = exports.isWorkloadEntity = exports.isDeploymentEntity = void 0;
+exports.getResources = exports.updateSelectorLabels = exports.updateSpecLabels = exports.updateImagePullSecrets = exports.updateObjectLabels = exports.getReplicaCount = exports.isIngressEntity = exports.isServiceEntity = exports.isWorkloadEntity = exports.isDeploymentEntity = void 0;
 const fs = require("fs");
 const core = require("@actions/core");
 const yaml = require("js-yaml");
@@ -31,6 +31,13 @@ function isServiceEntity(kind) {
     return string_comparison_1.isEqual("Service", kind, string_comparison_1.StringComparer.OrdinalIgnoreCase);
 }
 exports.isServiceEntity = isServiceEntity;
+function isIngressEntity(kind) {
+    if (!kind) {
+        throw ('ResourceKindNotDefined');
+    }
+    return string_comparison_1.isEqual("Ingress", kind, string_comparison_1.StringComparer.OrdinalIgnoreCase);
+}
+exports.isIngressEntity = isIngressEntity;
 function getReplicaCount(inputObject) {
     if (!inputObject) {
         throw ('NullInputObject');

--- a/lib/utilities/strategy-helpers/blue-green-helper.js
+++ b/lib/utilities/strategy-helpers/blue-green-helper.js
@@ -1,19 +1,75 @@
 'use strict';
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.fetchResource = exports.getServiceSelector = exports.getDeploymentMatchLabels = exports.getSpecLabel = exports.getBlueGreenResourceName = exports.addBlueGreenLabelsAndAnnotations = exports.getNewBlueGreenObject = exports.createWorkloadssWithLabel = exports.getManifestObjects = exports.getSuffix = exports.deleteWorkloadsAndServicesWithLabel = exports.cleanUp = exports.deleteWorkloadsWithLabel = exports.STABLE_SUFFIX = exports.BLUE_GREEN_SUFFIX = exports.BLUE_GREEN_VERSION_LABEL = exports.NONE_LABEL_VALUE = exports.BLUE_GREEN_NEW_LABEL_VALUE = void 0;
+exports.fetchResource = exports.isServiceSelectorSubsetOfMatchLabel = exports.getServiceSelector = exports.getDeploymentMatchLabels = exports.getSpecLabel = exports.getBlueGreenResourceName = exports.addBlueGreenLabelsAndAnnotations = exports.getNewBlueGreenObject = exports.createWorkloadsWithLabel = exports.getManifestObjects = exports.getSuffix = exports.deleteWorkloadsAndServicesWithLabel = exports.cleanUp = exports.deleteWorkloadsWithLabel = exports.routeBlueGreen = exports.isSMIRoute = exports.isIngressRoute = exports.isBlueGreenDeploymentStrategy = exports.STABLE_SUFFIX = exports.BLUE_GREEN_SUFFIX = exports.BLUE_GREEN_VERSION_LABEL = exports.NONE_LABEL_VALUE = exports.BLUE_GREEN_NEW_LABEL_VALUE = exports.BLUE_GREEN_DEPLOYMENT_STRATEGY = void 0;
 const core = require("@actions/core");
 const fs = require("fs");
 const yaml = require("js-yaml");
 const utility_1 = require("../utility");
 const constants_1 = require("../../constants");
-const string_comparison_1 = require("../string-comparison");
 const fileHelper = require("../files-helper");
 const helper = require("../resource-object-utility");
+const TaskInputParameters = require("../../input-parameters");
+const service_blue_green_helper_1 = require("./service-blue-green-helper");
+const ingress_blue_green_helper_1 = require("./ingress-blue-green-helper");
+const smi_blue_green_helper_1 = require("./smi-blue-green-helper");
+exports.BLUE_GREEN_DEPLOYMENT_STRATEGY = 'BLUE-GREEN';
 exports.BLUE_GREEN_NEW_LABEL_VALUE = 'green';
 exports.NONE_LABEL_VALUE = 'None';
 exports.BLUE_GREEN_VERSION_LABEL = 'k8s.deploy.color';
 exports.BLUE_GREEN_SUFFIX = '-green';
 exports.STABLE_SUFFIX = '-stable';
+const INGRESS_ROUTE = 'INGRESS';
+const SMI_ROUTE = 'SMI';
+function isBlueGreenDeploymentStrategy() {
+    const deploymentStrategy = TaskInputParameters.deploymentStrategy;
+    return deploymentStrategy && deploymentStrategy.toUpperCase() === exports.BLUE_GREEN_DEPLOYMENT_STRATEGY;
+}
+exports.isBlueGreenDeploymentStrategy = isBlueGreenDeploymentStrategy;
+function isIngressRoute() {
+    const routeMethod = TaskInputParameters.routeMethod;
+    return routeMethod && routeMethod.toUpperCase() === INGRESS_ROUTE;
+}
+exports.isIngressRoute = isIngressRoute;
+function isSMIRoute() {
+    const routeMethod = TaskInputParameters.routeMethod;
+    return routeMethod && routeMethod.toUpperCase() === SMI_ROUTE;
+}
+exports.isSMIRoute = isSMIRoute;
+function routeBlueGreen(kubectl, inputManifestFiles) {
+    return __awaiter(this, void 0, void 0, function* () {
+        // get buffer time
+        let bufferTime = parseInt(TaskInputParameters.versionSwitchBuffer);
+        //logging start of buffer time
+        let dateNow = new Date();
+        console.log('starting buffer time of ' + bufferTime + ' minute/s at ' + dateNow.toISOString() + ' UTC');
+        // waiting
+        yield utility_1.sleep(bufferTime * 1000 * 60);
+        // logging end of buffer time
+        dateNow = new Date();
+        console.log('stopping buffer time of ' + bufferTime + ' minute/s at ' + dateNow.toISOString() + ' UTC');
+        const manifestObjects = getManifestObjects(inputManifestFiles);
+        // routing to new deployments
+        if (isIngressRoute()) {
+            ingress_blue_green_helper_1.routeBlueGreenIngress(kubectl, exports.BLUE_GREEN_NEW_LABEL_VALUE, manifestObjects.serviceNameMap, manifestObjects.serviceEntityList, manifestObjects.ingressEntityList);
+        }
+        else if (isSMIRoute()) {
+            smi_blue_green_helper_1.routeBlueGreenSMI(kubectl, exports.BLUE_GREEN_NEW_LABEL_VALUE, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
+        }
+        else {
+            service_blue_green_helper_1.routeBlueGreenService(kubectl, exports.BLUE_GREEN_NEW_LABEL_VALUE, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
+        }
+    });
+}
+exports.routeBlueGreen = routeBlueGreen;
 function deleteWorkloadsWithLabel(kubectl, deleteLabel, deploymentEntityList) {
     let delList = [];
     deploymentEntityList.forEach((inputObject) => {
@@ -49,7 +105,9 @@ function cleanUp(kubectl, deploymentEntityList, serviceEntityList) {
         deploymentEntityList.forEach((depObject) => {
             const kind = depObject.kind;
             const name = depObject.metadata.name;
-            if (getServiceSelector(inputObject) && getDeploymentMatchLabels(depObject) && getServiceSelector(inputObject) === getDeploymentMatchLabels(depObject)) {
+            const serviceSelector = getServiceSelector(inputObject);
+            const matchLabels = getDeploymentMatchLabels(depObject);
+            if (!!serviceSelector && !!matchLabels && isServiceSelectorSubsetOfMatchLabel(serviceSelector, matchLabels)) {
                 const existingDeploy = fetchResource(kubectl, kind, name);
                 // checking if it has something to target
                 if (!existingDeploy) {
@@ -136,7 +194,7 @@ function getManifestObjects(filePaths) {
         });
     });
     let serviceNameMap = new Map();
-    // find all services and adding they names with blue green suffix 
+    // find all services and add their names with blue green suffix
     serviceEntityList.forEach(inputObject => {
         const name = inputObject.metadata.name;
         serviceNameMap.set(name, getBlueGreenResourceName(name, exports.BLUE_GREEN_SUFFIX));
@@ -144,12 +202,11 @@ function getManifestObjects(filePaths) {
     return { serviceEntityList: serviceEntityList, serviceNameMap: serviceNameMap, deploymentEntityList: deploymentEntityList, ingressEntityList: ingressEntityList, otherObjects: otherEntitiesList };
 }
 exports.getManifestObjects = getManifestObjects;
-function createWorkloadssWithLabel(kubectl, depObjectList, nextLabel) {
+function createWorkloadsWithLabel(kubectl, depObjectList, nextLabel) {
     const newObjectsList = [];
     depObjectList.forEach((inputObject) => {
-        const blueGreenReplicaCount = helper.getReplicaCount(inputObject);
         // creating deployment with label
-        const newBlueGreenObject = getNewBlueGreenObject(inputObject, blueGreenReplicaCount, nextLabel);
+        const newBlueGreenObject = getNewBlueGreenObject(inputObject, nextLabel);
         core.debug('New blue-green object is: ' + JSON.stringify(newBlueGreenObject));
         newObjectsList.push(newBlueGreenObject);
     });
@@ -157,8 +214,8 @@ function createWorkloadssWithLabel(kubectl, depObjectList, nextLabel) {
     const result = kubectl.apply(manifestFiles);
     return { 'result': result, 'newFilePaths': manifestFiles };
 }
-exports.createWorkloadssWithLabel = createWorkloadssWithLabel;
-function getNewBlueGreenObject(inputObject, replicas, labelValue) {
+exports.createWorkloadsWithLabel = createWorkloadsWithLabel;
+function getNewBlueGreenObject(inputObject, labelValue) {
     const newObject = JSON.parse(JSON.stringify(inputObject));
     // Updating name only if label is green label is given
     if (labelValue === exports.BLUE_GREEN_NEW_LABEL_VALUE) {
@@ -166,10 +223,6 @@ function getNewBlueGreenObject(inputObject, replicas, labelValue) {
     }
     // Adding labels and annotations
     addBlueGreenLabelsAndAnnotations(newObject, labelValue);
-    // Updating no. of replicas
-    if (isSpecContainsReplicas(newObject.kind)) {
-        newObject.spec.replicas = replicas;
-    }
     return newObject;
 }
 exports.getNewBlueGreenObject = getNewBlueGreenObject;
@@ -186,13 +239,8 @@ function addBlueGreenLabelsAndAnnotations(inputObject, labelValue) {
     }
 }
 exports.addBlueGreenLabelsAndAnnotations = addBlueGreenLabelsAndAnnotations;
-function isSpecContainsReplicas(kind) {
-    return !string_comparison_1.isEqual(kind, constants_1.KubernetesWorkload.pod, string_comparison_1.StringComparer.OrdinalIgnoreCase) &&
-        !string_comparison_1.isEqual(kind, constants_1.KubernetesWorkload.daemonSet, string_comparison_1.StringComparer.OrdinalIgnoreCase) &&
-        !helper.isServiceEntity(kind);
-}
 function getBlueGreenResourceName(name, suffix) {
-    return name + suffix;
+    return `${name}${suffix}`;
 }
 exports.getBlueGreenResourceName = getBlueGreenResourceName;
 function getSpecLabel(inputObject) {
@@ -203,13 +251,13 @@ function getSpecLabel(inputObject) {
 }
 exports.getSpecLabel = getSpecLabel;
 function getDeploymentMatchLabels(inputObject) {
-    if (inputObject.kind.toUpperCase() == 'POD' && !!inputObject && !!inputObject.metadata && !!inputObject.metadata.labels) {
+    if (inputObject.kind.toUpperCase() == constants_1.KubernetesWorkload.pod && !!inputObject && !!inputObject.metadata && !!inputObject.metadata.labels) {
         return JSON.stringify(inputObject.metadata.labels);
     }
     else if (!!inputObject && inputObject.spec && inputObject.spec.selector && inputObject.spec.selector.matchLabels) {
         return JSON.stringify(inputObject.spec.selector.matchLabels);
     }
-    return false;
+    return '';
 }
 exports.getDeploymentMatchLabels = getDeploymentMatchLabels;
 function getServiceSelector(inputObject) {
@@ -217,9 +265,27 @@ function getServiceSelector(inputObject) {
         return JSON.stringify(inputObject.spec.selector);
     }
     else
-        return false;
+        return '';
 }
 exports.getServiceSelector = getServiceSelector;
+function isServiceSelectorSubsetOfMatchLabel(serviceSelector, matchLabels) {
+    let serviceSelectorMap = new Map();
+    let matchLabelsMap = new Map();
+    JSON.parse(serviceSelector, (key, value) => {
+        serviceSelectorMap.set(key, value);
+    });
+    JSON.parse(matchLabels, (key, value) => {
+        matchLabelsMap.set(key, value);
+    });
+    let isMatch = true;
+    serviceSelectorMap.forEach((value, key) => {
+        if (!!key && (!matchLabelsMap.has(key) || matchLabelsMap.get(key)) != value) {
+            isMatch = false;
+        }
+    });
+    return isMatch;
+}
+exports.isServiceSelectorSubsetOfMatchLabel = isServiceSelectorSubsetOfMatchLabel;
 function fetchResource(kubectl, kind, name) {
     const result = kubectl.getResource(kind, name);
     if (result == null || !!result.stderr) {

--- a/lib/utilities/strategy-helpers/blue-green-helper.js
+++ b/lib/utilities/strategy-helpers/blue-green-helper.js
@@ -117,7 +117,7 @@ function deleteWorkloadsAndServicesWithLabel(kubectl, deleteLabel, deploymentEnt
     deletionEntitiesList.forEach((inputObject) => {
         const name = inputObject.metadata.name;
         const kind = inputObject.kind;
-        if (!deleteLabel) {
+        if (deleteLabel === exports.NONE_LABEL_VALUE) {
             // if not dellabel, delete stable objects
             const resourceToDelete = { name: name, kind: kind };
             resourcesToDelete.push(resourceToDelete);

--- a/lib/utilities/strategy-helpers/blue-green-helper.js
+++ b/lib/utilities/strategy-helpers/blue-green-helper.js
@@ -253,7 +253,7 @@ function getSpecLabel(inputObject) {
 }
 exports.getSpecLabel = getSpecLabel;
 function getDeploymentMatchLabels(deploymentObject) {
-    if (!!deploymentObject && deploymentObject.kind.toUpperCase() == constants_1.KubernetesWorkload.pod && !!deploymentObject && !!deploymentObject.metadata && !!deploymentObject.metadata.labels) {
+    if (!!deploymentObject && deploymentObject.kind.toUpperCase() == constants_1.KubernetesWorkload.pod.toUpperCase() && !!deploymentObject.metadata && !!deploymentObject.metadata.labels) {
         return JSON.stringify(deploymentObject.metadata.labels);
     }
     else if (!!deploymentObject && deploymentObject.spec && deploymentObject.spec.selector && deploymentObject.spec.selector.matchLabels) {

--- a/lib/utilities/strategy-helpers/blue-green-helper.js
+++ b/lib/utilities/strategy-helpers/blue-green-helper.js
@@ -9,7 +9,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.fetchResource = exports.isServiceSelectorSubsetOfMatchLabel = exports.getServiceSelector = exports.getDeploymentMatchLabels = exports.getSpecLabel = exports.getBlueGreenResourceName = exports.addBlueGreenLabelsAndAnnotations = exports.getNewBlueGreenObject = exports.createWorkloadsWithLabel = exports.getManifestObjects = exports.getSuffix = exports.deleteWorkloadsAndServicesWithLabel = exports.cleanUp = exports.deleteWorkloadsWithLabel = exports.routeBlueGreen = exports.isSMIRoute = exports.isIngressRoute = exports.isBlueGreenDeploymentStrategy = exports.STABLE_SUFFIX = exports.BLUE_GREEN_SUFFIX = exports.BLUE_GREEN_VERSION_LABEL = exports.NONE_LABEL_VALUE = exports.BLUE_GREEN_NEW_LABEL_VALUE = exports.BLUE_GREEN_DEPLOYMENT_STRATEGY = void 0;
+exports.fetchResource = exports.isServiceSelectorSubsetOfMatchLabel = exports.getServiceSelector = exports.getDeploymentMatchLabels = exports.getSpecLabel = exports.getBlueGreenResourceName = exports.addBlueGreenLabelsAndAnnotations = exports.getNewBlueGreenObject = exports.createWorkloadsWithLabel = exports.isServiceRouted = exports.getManifestObjects = exports.getSuffix = exports.deleteObjects = exports.deleteWorkloadsAndServicesWithLabel = exports.cleanUp = exports.deleteWorkloadsWithLabel = exports.routeBlueGreen = exports.isSMIRoute = exports.isIngressRoute = exports.isBlueGreenDeploymentStrategy = exports.STABLE_SUFFIX = exports.GREEN_SUFFIX = exports.BLUE_GREEN_VERSION_LABEL = exports.NONE_LABEL_VALUE = exports.GREEN_LABEL_VALUE = exports.BLUE_GREEN_DEPLOYMENT_STRATEGY = void 0;
 const core = require("@actions/core");
 const fs = require("fs");
 const yaml = require("js-yaml");
@@ -22,10 +22,10 @@ const service_blue_green_helper_1 = require("./service-blue-green-helper");
 const ingress_blue_green_helper_1 = require("./ingress-blue-green-helper");
 const smi_blue_green_helper_1 = require("./smi-blue-green-helper");
 exports.BLUE_GREEN_DEPLOYMENT_STRATEGY = 'BLUE-GREEN';
-exports.BLUE_GREEN_NEW_LABEL_VALUE = 'green';
+exports.GREEN_LABEL_VALUE = 'green';
 exports.NONE_LABEL_VALUE = 'None';
 exports.BLUE_GREEN_VERSION_LABEL = 'k8s.deploy.color';
-exports.BLUE_GREEN_SUFFIX = '-green';
+exports.GREEN_SUFFIX = '-green';
 exports.STABLE_SUFFIX = '-stable';
 const INGRESS_ROUTE = 'INGRESS';
 const SMI_ROUTE = 'SMI';
@@ -59,93 +59,79 @@ function routeBlueGreen(kubectl, inputManifestFiles) {
         const manifestObjects = getManifestObjects(inputManifestFiles);
         // routing to new deployments
         if (isIngressRoute()) {
-            ingress_blue_green_helper_1.routeBlueGreenIngress(kubectl, exports.BLUE_GREEN_NEW_LABEL_VALUE, manifestObjects.serviceNameMap, manifestObjects.serviceEntityList, manifestObjects.ingressEntityList);
+            ingress_blue_green_helper_1.routeBlueGreenIngress(kubectl, exports.GREEN_LABEL_VALUE, manifestObjects.serviceNameMap, manifestObjects.serviceEntityList, manifestObjects.ingressEntityList);
         }
         else if (isSMIRoute()) {
-            smi_blue_green_helper_1.routeBlueGreenSMI(kubectl, exports.BLUE_GREEN_NEW_LABEL_VALUE, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
+            smi_blue_green_helper_1.routeBlueGreenSMI(kubectl, exports.GREEN_LABEL_VALUE, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
         }
         else {
-            service_blue_green_helper_1.routeBlueGreenService(kubectl, exports.BLUE_GREEN_NEW_LABEL_VALUE, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
+            service_blue_green_helper_1.routeBlueGreenService(kubectl, exports.GREEN_LABEL_VALUE, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
         }
     });
 }
 exports.routeBlueGreen = routeBlueGreen;
 function deleteWorkloadsWithLabel(kubectl, deleteLabel, deploymentEntityList) {
-    let delList = [];
+    let resourcesToDelete = [];
     deploymentEntityList.forEach((inputObject) => {
         const name = inputObject.metadata.name;
         const kind = inputObject.kind;
         if (deleteLabel === exports.NONE_LABEL_VALUE) {
             // if dellabel is none, deletes stable deployments
-            const tempObject = { name: name, kind: kind };
-            delList.push(tempObject);
+            const resourceToDelete = { name: name, kind: kind };
+            resourcesToDelete.push(resourceToDelete);
         }
         else {
             // if dellabel is not none, then deletes new green deployments
-            const tempObject = { name: name + exports.BLUE_GREEN_SUFFIX, kind: kind };
-            delList.push(tempObject);
+            const resourceToDelete = { name: getBlueGreenResourceName(name, exports.GREEN_SUFFIX), kind: kind };
+            resourcesToDelete.push(resourceToDelete);
         }
     });
     // deletes the deployments
-    delList.forEach((delObject) => {
-        try {
-            const result = kubectl.delete([delObject.kind, delObject.name]);
-            utility_1.checkForErrors([result]);
-        }
-        catch (ex) {
-            // Ignore failures of delete if doesn't exist
-        }
-    });
+    deleteObjects(kubectl, resourcesToDelete);
 }
 exports.deleteWorkloadsWithLabel = deleteWorkloadsWithLabel;
 function cleanUp(kubectl, deploymentEntityList, serviceEntityList) {
     // checks if services has some stable deployments to target or deletes them too
-    let delList = [];
-    serviceEntityList.forEach((inputObject) => {
-        deploymentEntityList.forEach((depObject) => {
-            const kind = depObject.kind;
-            const name = depObject.metadata.name;
-            const serviceSelector = getServiceSelector(inputObject);
-            const matchLabels = getDeploymentMatchLabels(depObject);
-            if (!!serviceSelector && !!matchLabels && isServiceSelectorSubsetOfMatchLabel(serviceSelector, matchLabels)) {
-                const existingDeploy = fetchResource(kubectl, kind, name);
-                // checking if it has something to target
-                if (!existingDeploy) {
-                    const tempObject = { name: inputObject.metadata.name, kind: inputObject.kind };
-                    delList.push(tempObject);
+    let deleteList = [];
+    deploymentEntityList.forEach((deploymentObject) => {
+        const existingDeploy = fetchResource(kubectl, deploymentObject.kind, deploymentObject.metadata.name);
+        if (!existingDeploy) {
+            serviceEntityList.forEach((serviceObject) => {
+                const serviceSelector = getServiceSelector(serviceObject);
+                const matchLabels = getDeploymentMatchLabels(deploymentObject);
+                if (!!serviceSelector && !!matchLabels && isServiceSelectorSubsetOfMatchLabel(serviceSelector, matchLabels)) {
+                    const resourceToDelete = { name: serviceObject.metadata.name, kind: serviceObject.kind };
+                    deleteList.push(resourceToDelete);
                 }
-            }
-        });
-    });
-    delList.forEach((delObject) => {
-        try {
-            const result = kubectl.delete([delObject.kind, delObject.name]);
-            utility_1.checkForErrors([result]);
-        }
-        catch (ex) {
-            // Ignore failures of delete if doesn't exist
+            });
         }
     });
+    // delete service not targeting a deployment
+    deleteObjects(kubectl, deleteList);
 }
 exports.cleanUp = cleanUp;
 function deleteWorkloadsAndServicesWithLabel(kubectl, deleteLabel, deploymentEntityList, serviceEntityList) {
     // need to delete services and deployments
     const deletionEntitiesList = deploymentEntityList.concat(serviceEntityList);
-    let deleteList = [];
+    let resourcesToDelete = [];
     deletionEntitiesList.forEach((inputObject) => {
         const name = inputObject.metadata.name;
         const kind = inputObject.kind;
         if (!deleteLabel) {
             // if not dellabel, delete stable objects
-            const tempObject = { name: name, kind: kind };
-            deleteList.push(tempObject);
+            const resourceToDelete = { name: name, kind: kind };
+            resourcesToDelete.push(resourceToDelete);
         }
         else {
             // else delete green labels
-            const tempObject = { name: name + exports.BLUE_GREEN_SUFFIX, kind: kind };
-            deleteList.push(tempObject);
+            const resourceToDelete = { name: getBlueGreenResourceName(name, exports.GREEN_SUFFIX), kind: kind };
+            resourcesToDelete.push(resourceToDelete);
         }
     });
+    deleteObjects(kubectl, resourcesToDelete);
+}
+exports.deleteWorkloadsAndServicesWithLabel = deleteWorkloadsAndServicesWithLabel;
+function deleteObjects(kubectl, deleteList) {
     // delete services and deployments
     deleteList.forEach((delObject) => {
         try {
@@ -157,10 +143,10 @@ function deleteWorkloadsAndServicesWithLabel(kubectl, deleteLabel, deploymentEnt
         }
     });
 }
-exports.deleteWorkloadsAndServicesWithLabel = deleteWorkloadsAndServicesWithLabel;
+exports.deleteObjects = deleteObjects;
 function getSuffix(label) {
-    if (label === exports.BLUE_GREEN_NEW_LABEL_VALUE) {
-        return exports.BLUE_GREEN_SUFFIX;
+    if (label === exports.GREEN_LABEL_VALUE) {
+        return exports.GREEN_SUFFIX;
     }
     else {
         return '';
@@ -197,14 +183,30 @@ function getManifestObjects(filePaths) {
     // find all services and add their names with blue green suffix
     serviceEntityList.forEach(inputObject => {
         const name = inputObject.metadata.name;
-        serviceNameMap.set(name, getBlueGreenResourceName(name, exports.BLUE_GREEN_SUFFIX));
+        serviceNameMap.set(name, getBlueGreenResourceName(name, exports.GREEN_SUFFIX));
     });
     return { serviceEntityList: serviceEntityList, serviceNameMap: serviceNameMap, deploymentEntityList: deploymentEntityList, ingressEntityList: ingressEntityList, otherObjects: otherEntitiesList };
 }
 exports.getManifestObjects = getManifestObjects;
-function createWorkloadsWithLabel(kubectl, depObjectList, nextLabel) {
+function isServiceRouted(serviceObject, deploymentEntityList) {
+    let shouldBeRouted = false;
+    const serviceSelector = getServiceSelector(serviceObject);
+    if (!!serviceSelector) {
+        deploymentEntityList.every((depObject) => {
+            // finding if there is a deployment in the given manifests the service targets
+            const matchLabels = getDeploymentMatchLabels(depObject);
+            if (!!matchLabels && isServiceSelectorSubsetOfMatchLabel(serviceSelector, matchLabels)) {
+                shouldBeRouted = true;
+                return false;
+            }
+        });
+    }
+    return shouldBeRouted;
+}
+exports.isServiceRouted = isServiceRouted;
+function createWorkloadsWithLabel(kubectl, deploymentObjectList, nextLabel) {
     const newObjectsList = [];
-    depObjectList.forEach((inputObject) => {
+    deploymentObjectList.forEach((inputObject) => {
         // creating deployment with label
         const newBlueGreenObject = getNewBlueGreenObject(inputObject, nextLabel);
         core.debug('New blue-green object is: ' + JSON.stringify(newBlueGreenObject));
@@ -218,8 +220,8 @@ exports.createWorkloadsWithLabel = createWorkloadsWithLabel;
 function getNewBlueGreenObject(inputObject, labelValue) {
     const newObject = JSON.parse(JSON.stringify(inputObject));
     // Updating name only if label is green label is given
-    if (labelValue === exports.BLUE_GREEN_NEW_LABEL_VALUE) {
-        newObject.metadata.name = getBlueGreenResourceName(inputObject.metadata.name, exports.BLUE_GREEN_SUFFIX);
+    if (labelValue === exports.GREEN_LABEL_VALUE) {
+        newObject.metadata.name = getBlueGreenResourceName(inputObject.metadata.name, exports.GREEN_SUFFIX);
     }
     // Adding labels and annotations
     addBlueGreenLabelsAndAnnotations(newObject, labelValue);
@@ -250,19 +252,19 @@ function getSpecLabel(inputObject) {
     return '';
 }
 exports.getSpecLabel = getSpecLabel;
-function getDeploymentMatchLabels(inputObject) {
-    if (inputObject.kind.toUpperCase() == constants_1.KubernetesWorkload.pod && !!inputObject && !!inputObject.metadata && !!inputObject.metadata.labels) {
-        return JSON.stringify(inputObject.metadata.labels);
+function getDeploymentMatchLabels(deploymentObject) {
+    if (!!deploymentObject && deploymentObject.kind.toUpperCase() == constants_1.KubernetesWorkload.pod && !!deploymentObject && !!deploymentObject.metadata && !!deploymentObject.metadata.labels) {
+        return JSON.stringify(deploymentObject.metadata.labels);
     }
-    else if (!!inputObject && inputObject.spec && inputObject.spec.selector && inputObject.spec.selector.matchLabels) {
-        return JSON.stringify(inputObject.spec.selector.matchLabels);
+    else if (!!deploymentObject && deploymentObject.spec && deploymentObject.spec.selector && deploymentObject.spec.selector.matchLabels) {
+        return JSON.stringify(deploymentObject.spec.selector.matchLabels);
     }
     return '';
 }
 exports.getDeploymentMatchLabels = getDeploymentMatchLabels;
-function getServiceSelector(inputObject) {
-    if (!!inputObject && inputObject.spec && inputObject.spec.selector) {
-        return JSON.stringify(inputObject.spec.selector);
+function getServiceSelector(serviceObject) {
+    if (!!serviceObject && serviceObject.spec && serviceObject.spec.selector) {
+        return JSON.stringify(serviceObject.spec.selector);
     }
     else
         return '';

--- a/lib/utilities/strategy-helpers/blue-green-helper.js
+++ b/lib/utilities/strategy-helpers/blue-green-helper.js
@@ -1,0 +1,262 @@
+'use strict';
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.fetchResource = exports.getServiceSelector = exports.getDeploymentMatchLabels = exports.getSpecLabel = exports.getBlueGreenResourceName = exports.addBlueGreenLabelsAndAnnotations = exports.getNewBlueGreenObject = exports.createWorkloadssWithLabel = exports.getManifestObjects = exports.getSuffix = exports.deleteWorkloadsAndServicesWithLabel = exports.cleanUp = exports.deleteWorkloadsWithLabel = exports.STABLE_SUFFIX = exports.BLUE_GREEN_SUFFIX = exports.BLUE_GREEN_VERSION_LABEL = exports.NONE_LABEL_VALUE = exports.BLUE_GREEN_NEW_LABEL_VALUE = void 0;
+const core = require("@actions/core");
+const fs = require("fs");
+const yaml = require("js-yaml");
+const utility_1 = require("../utility");
+const constants_1 = require("../../constants");
+const string_comparison_1 = require("../string-comparison");
+const fileHelper = require("../files-helper");
+const helper = require("../resource-object-utility");
+exports.BLUE_GREEN_NEW_LABEL_VALUE = 'green';
+exports.NONE_LABEL_VALUE = 'None';
+exports.BLUE_GREEN_VERSION_LABEL = 'k8s.deploy.color';
+exports.BLUE_GREEN_SUFFIX = '-green';
+exports.STABLE_SUFFIX = '-stable';
+function deleteWorkloadsWithLabel(kubectl, deleteLabel, deploymentEntityList) {
+    let delList = [];
+    deploymentEntityList.forEach((inputObject) => {
+        const name = inputObject.metadata.name;
+        const kind = inputObject.kind;
+        if (deleteLabel === exports.NONE_LABEL_VALUE) {
+            // if dellabel is none, deletes stable deployments
+            const tempObject = { name: name, kind: kind };
+            delList.push(tempObject);
+        }
+        else {
+            // if dellabel is not none, then deletes new green deployments
+            const tempObject = { name: name + exports.BLUE_GREEN_SUFFIX, kind: kind };
+            delList.push(tempObject);
+        }
+    });
+    // deletes the deployments
+    delList.forEach((delObject) => {
+        try {
+            const result = kubectl.delete([delObject.kind, delObject.name]);
+            utility_1.checkForErrors([result]);
+        }
+        catch (ex) {
+            // Ignore failures of delete if doesn't exist
+        }
+    });
+}
+exports.deleteWorkloadsWithLabel = deleteWorkloadsWithLabel;
+function cleanUp(kubectl, deploymentEntityList, serviceEntityList) {
+    // checks if services has some stable deployments to target or deletes them too
+    let delList = [];
+    serviceEntityList.forEach((inputObject) => {
+        deploymentEntityList.forEach((depObject) => {
+            const kind = depObject.kind;
+            const name = depObject.metadata.name;
+            if (getServiceSelector(inputObject) && getDeploymentMatchLabels(depObject) && getServiceSelector(inputObject) === getDeploymentMatchLabels(depObject)) {
+                const existingDeploy = fetchResource(kubectl, kind, name);
+                // checking if it has something to target
+                if (!existingDeploy) {
+                    const tempObject = { name: inputObject.metadata.name, kind: inputObject.kind };
+                    delList.push(tempObject);
+                }
+            }
+        });
+    });
+    delList.forEach((delObject) => {
+        try {
+            const result = kubectl.delete([delObject.kind, delObject.name]);
+            utility_1.checkForErrors([result]);
+        }
+        catch (ex) {
+            // Ignore failures of delete if doesn't exist
+        }
+    });
+}
+exports.cleanUp = cleanUp;
+function deleteWorkloadsAndServicesWithLabel(kubectl, deleteLabel, deploymentEntityList, serviceEntityList) {
+    // need to delete services and deployments
+    const deletionEntitiesList = deploymentEntityList.concat(serviceEntityList);
+    let deleteList = [];
+    deletionEntitiesList.forEach((inputObject) => {
+        const name = inputObject.metadata.name;
+        const kind = inputObject.kind;
+        if (!deleteLabel) {
+            // if not dellabel, delete stable objects
+            const tempObject = { name: name, kind: kind };
+            deleteList.push(tempObject);
+        }
+        else {
+            // else delete green labels
+            const tempObject = { name: name + exports.BLUE_GREEN_SUFFIX, kind: kind };
+            deleteList.push(tempObject);
+        }
+    });
+    // delete services and deployments
+    deleteList.forEach((delObject) => {
+        try {
+            const result = kubectl.delete([delObject.kind, delObject.name]);
+            utility_1.checkForErrors([result]);
+        }
+        catch (ex) {
+            // Ignore failures of delete if doesn't exist
+        }
+    });
+}
+exports.deleteWorkloadsAndServicesWithLabel = deleteWorkloadsAndServicesWithLabel;
+function getSuffix(label) {
+    if (label === exports.BLUE_GREEN_NEW_LABEL_VALUE) {
+        return exports.BLUE_GREEN_SUFFIX;
+    }
+    else {
+        return '';
+    }
+}
+exports.getSuffix = getSuffix;
+// other common functions
+function getManifestObjects(filePaths) {
+    const deploymentEntityList = [];
+    const serviceEntityList = [];
+    const ingressEntityList = [];
+    const otherEntitiesList = [];
+    filePaths.forEach((filePath) => {
+        const fileContents = fs.readFileSync(filePath);
+        yaml.safeLoadAll(fileContents, function (inputObject) {
+            if (!!inputObject) {
+                const kind = inputObject.kind;
+                if (helper.isDeploymentEntity(kind)) {
+                    deploymentEntityList.push(inputObject);
+                }
+                else if (helper.isServiceEntity(kind)) {
+                    serviceEntityList.push(inputObject);
+                }
+                else if (helper.isIngressEntity(kind)) {
+                    ingressEntityList.push(inputObject);
+                }
+                else {
+                    otherEntitiesList.push(inputObject);
+                }
+            }
+        });
+    });
+    let serviceNameMap = new Map();
+    // find all services and adding they names with blue green suffix 
+    serviceEntityList.forEach(inputObject => {
+        const name = inputObject.metadata.name;
+        serviceNameMap.set(name, getBlueGreenResourceName(name, exports.BLUE_GREEN_SUFFIX));
+    });
+    return { serviceEntityList: serviceEntityList, serviceNameMap: serviceNameMap, deploymentEntityList: deploymentEntityList, ingressEntityList: ingressEntityList, otherObjects: otherEntitiesList };
+}
+exports.getManifestObjects = getManifestObjects;
+function createWorkloadssWithLabel(kubectl, depObjectList, nextLabel) {
+    const newObjectsList = [];
+    depObjectList.forEach((inputObject) => {
+        const blueGreenReplicaCount = helper.getReplicaCount(inputObject);
+        // creating deployment with label
+        const newBlueGreenObject = getNewBlueGreenObject(inputObject, blueGreenReplicaCount, nextLabel);
+        core.debug('New blue-green object is: ' + JSON.stringify(newBlueGreenObject));
+        newObjectsList.push(newBlueGreenObject);
+    });
+    const manifestFiles = fileHelper.writeObjectsToFile(newObjectsList);
+    const result = kubectl.apply(manifestFiles);
+    return { 'result': result, 'newFilePaths': manifestFiles };
+}
+exports.createWorkloadssWithLabel = createWorkloadssWithLabel;
+function getNewBlueGreenObject(inputObject, replicas, labelValue) {
+    const newObject = JSON.parse(JSON.stringify(inputObject));
+    // Updating name only if label is green label is given
+    if (labelValue === exports.BLUE_GREEN_NEW_LABEL_VALUE) {
+        newObject.metadata.name = getBlueGreenResourceName(inputObject.metadata.name, exports.BLUE_GREEN_SUFFIX);
+    }
+    // Adding labels and annotations
+    addBlueGreenLabelsAndAnnotations(newObject, labelValue);
+    // Updating no. of replicas
+    if (isSpecContainsReplicas(newObject.kind)) {
+        newObject.spec.replicas = replicas;
+    }
+    return newObject;
+}
+exports.getNewBlueGreenObject = getNewBlueGreenObject;
+function addBlueGreenLabelsAndAnnotations(inputObject, labelValue) {
+    //creating the k8s.deploy.color label
+    const newLabels = new Map();
+    newLabels[exports.BLUE_GREEN_VERSION_LABEL] = labelValue;
+    // updating object labels and selector labels
+    helper.updateObjectLabels(inputObject, newLabels, false);
+    helper.updateSelectorLabels(inputObject, newLabels, false);
+    // updating spec labels if it is a service
+    if (!helper.isServiceEntity(inputObject.kind)) {
+        helper.updateSpecLabels(inputObject, newLabels, false);
+    }
+}
+exports.addBlueGreenLabelsAndAnnotations = addBlueGreenLabelsAndAnnotations;
+function isSpecContainsReplicas(kind) {
+    return !string_comparison_1.isEqual(kind, constants_1.KubernetesWorkload.pod, string_comparison_1.StringComparer.OrdinalIgnoreCase) &&
+        !string_comparison_1.isEqual(kind, constants_1.KubernetesWorkload.daemonSet, string_comparison_1.StringComparer.OrdinalIgnoreCase) &&
+        !helper.isServiceEntity(kind);
+}
+function getBlueGreenResourceName(name, suffix) {
+    return name + suffix;
+}
+exports.getBlueGreenResourceName = getBlueGreenResourceName;
+function getSpecLabel(inputObject) {
+    if (!!inputObject && inputObject.spec && inputObject.spec.selector && inputObject.spec.selector.matchLabels && inputObject.spec.selector.matchLabels[exports.BLUE_GREEN_VERSION_LABEL]) {
+        return inputObject.spec.selector.matchLabels[exports.BLUE_GREEN_VERSION_LABEL];
+    }
+    return '';
+}
+exports.getSpecLabel = getSpecLabel;
+function getDeploymentMatchLabels(inputObject) {
+    if (inputObject.kind.toUpperCase() == 'POD' && !!inputObject && !!inputObject.metadata && !!inputObject.metadata.labels) {
+        return JSON.stringify(inputObject.metadata.labels);
+    }
+    else if (!!inputObject && inputObject.spec && inputObject.spec.selector && inputObject.spec.selector.matchLabels) {
+        return JSON.stringify(inputObject.spec.selector.matchLabels);
+    }
+    return false;
+}
+exports.getDeploymentMatchLabels = getDeploymentMatchLabels;
+function getServiceSelector(inputObject) {
+    if (!!inputObject && inputObject.spec && inputObject.spec.selector) {
+        return JSON.stringify(inputObject.spec.selector);
+    }
+    else
+        return false;
+}
+exports.getServiceSelector = getServiceSelector;
+function fetchResource(kubectl, kind, name) {
+    const result = kubectl.getResource(kind, name);
+    if (result == null || !!result.stderr) {
+        return null;
+    }
+    if (!!result.stdout) {
+        const resource = JSON.parse(result.stdout);
+        try {
+            UnsetsClusterSpecficDetails(resource);
+            return resource;
+        }
+        catch (ex) {
+            core.debug('Exception occurred while Parsing ' + resource + ' in Json object');
+            core.debug(`Exception:${ex}`);
+        }
+    }
+    return null;
+}
+exports.fetchResource = fetchResource;
+function UnsetsClusterSpecficDetails(resource) {
+    if (resource == null) {
+        return;
+    }
+    // Unsets the cluster specific details in the object
+    if (!!resource) {
+        const metadata = resource.metadata;
+        const status = resource.status;
+        if (!!metadata) {
+            const newMetadata = {
+                'annotations': metadata.annotations,
+                'labels': metadata.labels,
+                'name': metadata.name
+            };
+            resource.metadata = newMetadata;
+        }
+        if (!!status) {
+            resource.status = {};
+        }
+    }
+}

--- a/lib/utilities/strategy-helpers/deployment-helper.js
+++ b/lib/utilities/strategy-helpers/deployment-helper.js
@@ -1,17 +1,16 @@
 'use strict';
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
         function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.deploy = void 0;
+exports.getManifestFiles = exports.deploy = void 0;
 const fs = require("fs");
-const path = require("path");
-const core = require("@actions/core");
 const yaml = require("js-yaml");
 const canaryDeploymentHelper = require("./canary-deployment-helper");
 const KubernetesObjectUtility = require("../resource-object-utility");
@@ -21,22 +20,27 @@ const fileHelper = require("../files-helper");
 const utils = require("../manifest-utilities");
 const KubernetesManifestUtility = require("../manifest-stability-utility");
 const KubernetesConstants = require("../../constants");
+const manifest_utilities_1 = require("../manifest-utilities");
 const pod_canary_deployment_helper_1 = require("./pod-canary-deployment-helper");
 const smi_canary_deployment_helper_1 = require("./smi-canary-deployment-helper");
 const utility_1 = require("../utility");
+const blue_green_helper_1 = require("./blue-green-helper");
+const service_blue_green_helper_1 = require("./service-blue-green-helper");
+const ingress_blue_green_helper_1 = require("./ingress-blue-green-helper");
+const smi_blue_green_helper_1 = require("./smi-blue-green-helper");
 function deploy(kubectl, manifestFilePaths, deploymentStrategy) {
     return __awaiter(this, void 0, void 0, function* () {
         // get manifest files
-        let inputManifestFiles = getManifestFiles(manifestFilePaths);
-        // artifact substitution
-        inputManifestFiles = updateContainerImagesInManifestFiles(inputManifestFiles, TaskInputParameters.containers);
-        // imagePullSecrets addition
-        inputManifestFiles = updateImagePullSecretsInManifestFiles(inputManifestFiles, TaskInputParameters.imagePullSecrets);
+        let inputManifestFiles = manifest_utilities_1.getUpdatedManifestFiles(manifestFilePaths);
         // deployment
-        const deployedManifestFiles = deployManifests(inputManifestFiles, kubectl, isCanaryDeploymentStrategy(deploymentStrategy));
+        const deployedManifestFiles = deployManifests(inputManifestFiles, kubectl, isCanaryDeploymentStrategy(deploymentStrategy), service_blue_green_helper_1.isBlueGreenDeploymentStrategy());
         // check manifest stability
         const resourceTypes = KubernetesObjectUtility.getResources(deployedManifestFiles, models.deploymentTypes.concat([KubernetesConstants.DiscoveryAndLoadBalancerResource.service]));
         yield checkManifestStability(kubectl, resourceTypes);
+        // route blue-green deployments
+        if (service_blue_green_helper_1.isBlueGreenDeploymentStrategy()) {
+            yield routeBlueGreen(kubectl, inputManifestFiles);
+        }
         // print ingress resources
         const ingressResources = KubernetesObjectUtility.getResources(deployedManifestFiles, [KubernetesConstants.DiscoveryAndLoadBalancerResource.ingress]);
         ingressResources.forEach(ingressResource => {
@@ -45,6 +49,31 @@ function deploy(kubectl, manifestFilePaths, deploymentStrategy) {
     });
 }
 exports.deploy = deploy;
+function routeBlueGreen(kubectl, inputManifestFiles) {
+    return __awaiter(this, void 0, void 0, function* () {
+        // get buffer time
+        let sleepTime = parseInt(TaskInputParameters.versionSwitchBuffer);
+        //logging start of buffer time
+        let temp = new Date();
+        console.log('starting buffer time of ' + sleepTime + ' minute/s at ' + temp.getHours() + ':' + temp.getMinutes() + ':' + temp.getSeconds() + ' UTC');
+        // waiting
+        yield utility_1.sleep(sleepTime * 1000 * 60);
+        // logging end of buffer time
+        temp = new Date();
+        console.log('stopping buffer time of ' + sleepTime + ' minute/s at ' + temp.getHours() + ':' + temp.getMinutes() + ':' + temp.getSeconds() + ' UTC');
+        const manifestObjects = blue_green_helper_1.getManifestObjects(inputManifestFiles);
+        // routing to new deployments
+        if (ingress_blue_green_helper_1.isIngressRoute()) {
+            ingress_blue_green_helper_1.blueGreenRouteIngress(kubectl, blue_green_helper_1.BLUE_GREEN_NEW_LABEL_VALUE, manifestObjects.serviceNameMap, manifestObjects.serviceEntityList, manifestObjects.ingressEntityList);
+        }
+        else if (smi_blue_green_helper_1.isSMIRoute()) {
+            smi_blue_green_helper_1.blueGreenRouteTraffic(kubectl, blue_green_helper_1.BLUE_GREEN_NEW_LABEL_VALUE, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
+        }
+        else {
+            service_blue_green_helper_1.blueGreenRouteService(kubectl, blue_green_helper_1.BLUE_GREEN_NEW_LABEL_VALUE, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
+        }
+    });
+}
 function getManifestFiles(manifestFilePaths) {
     const files = utils.getManifestFiles(manifestFilePaths);
     if (files == null || files.length === 0) {
@@ -52,7 +81,8 @@ function getManifestFiles(manifestFilePaths) {
     }
     return files;
 }
-function deployManifests(files, kubectl, isCanaryDeploymentStrategy) {
+exports.getManifestFiles = getManifestFiles;
+function deployManifests(files, kubectl, isCanaryDeploymentStrategy, isBlueGreenDeploymentStrategy) {
     let result;
     if (isCanaryDeploymentStrategy) {
         let canaryDeploymentOutput;
@@ -64,6 +94,20 @@ function deployManifests(files, kubectl, isCanaryDeploymentStrategy) {
         }
         result = canaryDeploymentOutput.result;
         files = canaryDeploymentOutput.newFilePaths;
+    }
+    else if (isBlueGreenDeploymentStrategy) {
+        let blueGreenDeploymentOutput;
+        if (ingress_blue_green_helper_1.isIngressRoute()) {
+            blueGreenDeploymentOutput = ingress_blue_green_helper_1.deployBlueGreenIngress(kubectl, files);
+        }
+        else if (smi_blue_green_helper_1.isSMIRoute()) {
+            blueGreenDeploymentOutput = smi_blue_green_helper_1.deployBlueGreenSMI(kubectl, files);
+        }
+        else {
+            blueGreenDeploymentOutput = service_blue_green_helper_1.deployBlueGreen(kubectl, files);
+        }
+        result = blueGreenDeploymentOutput.result;
+        files = blueGreenDeploymentOutput.newFilePaths;
     }
     else {
         if (canaryDeploymentHelper.isSMICanaryStrategy()) {
@@ -101,50 +145,6 @@ function checkManifestStability(kubectl, resources) {
     return __awaiter(this, void 0, void 0, function* () {
         yield KubernetesManifestUtility.checkManifestStability(kubectl, resources);
     });
-}
-function updateContainerImagesInManifestFiles(filePaths, containers) {
-    if (!!containers && containers.length > 0) {
-        const newFilePaths = [];
-        const tempDirectory = fileHelper.getTempDirectory();
-        filePaths.forEach((filePath) => {
-            let contents = fs.readFileSync(filePath).toString();
-            containers.forEach((container) => {
-                let imageName = container.split(':')[0];
-                if (imageName.indexOf('@') > 0) {
-                    imageName = imageName.split('@')[0];
-                }
-                if (contents.indexOf(imageName) > 0) {
-                    contents = utils.substituteImageNameInSpecFile(contents, imageName, container);
-                }
-            });
-            const fileName = path.join(tempDirectory, path.basename(filePath));
-            fs.writeFileSync(path.join(fileName), contents);
-            newFilePaths.push(fileName);
-        });
-        return newFilePaths;
-    }
-    return filePaths;
-}
-function updateImagePullSecretsInManifestFiles(filePaths, imagePullSecrets) {
-    if (!!imagePullSecrets && imagePullSecrets.length > 0) {
-        const newObjectsList = [];
-        filePaths.forEach((filePath) => {
-            const fileContents = fs.readFileSync(filePath).toString();
-            yaml.safeLoadAll(fileContents, function (inputObject) {
-                if (!!inputObject && !!inputObject.kind) {
-                    const kind = inputObject.kind;
-                    if (KubernetesObjectUtility.isWorkloadEntity(kind)) {
-                        KubernetesObjectUtility.updateImagePullSecrets(inputObject, imagePullSecrets, false);
-                    }
-                    newObjectsList.push(inputObject);
-                }
-            });
-        });
-        core.debug('New K8s objects after addin imagePullSecrets are :' + JSON.stringify(newObjectsList));
-        const newFilePaths = fileHelper.writeObjectsToFile(newObjectsList);
-        return newFilePaths;
-    }
-    return filePaths;
 }
 function isCanaryDeploymentStrategy(deploymentStrategy) {
     return deploymentStrategy != null && deploymentStrategy.toUpperCase() === canaryDeploymentHelper.CANARY_DEPLOYMENT_STRATEGY.toUpperCase();

--- a/lib/utilities/strategy-helpers/deployment-helper.js
+++ b/lib/utilities/strategy-helpers/deployment-helper.js
@@ -33,13 +33,13 @@ function deploy(kubectl, manifestFilePaths, deploymentStrategy) {
         // get manifest files
         let inputManifestFiles = manifest_utilities_1.getUpdatedManifestFiles(manifestFilePaths);
         // deployment
-        const deployedManifestFiles = deployManifests(inputManifestFiles, kubectl, isCanaryDeploymentStrategy(deploymentStrategy), service_blue_green_helper_1.isBlueGreenDeploymentStrategy());
+        const deployedManifestFiles = deployManifests(inputManifestFiles, kubectl, isCanaryDeploymentStrategy(deploymentStrategy), blue_green_helper_1.isBlueGreenDeploymentStrategy());
         // check manifest stability
         const resourceTypes = KubernetesObjectUtility.getResources(deployedManifestFiles, models.deploymentTypes.concat([KubernetesConstants.DiscoveryAndLoadBalancerResource.service]));
         yield checkManifestStability(kubectl, resourceTypes);
         // route blue-green deployments
-        if (service_blue_green_helper_1.isBlueGreenDeploymentStrategy()) {
-            yield routeBlueGreen(kubectl, inputManifestFiles);
+        if (blue_green_helper_1.isBlueGreenDeploymentStrategy()) {
+            yield blue_green_helper_1.routeBlueGreen(kubectl, inputManifestFiles);
         }
         // print ingress resources
         const ingressResources = KubernetesObjectUtility.getResources(deployedManifestFiles, [KubernetesConstants.DiscoveryAndLoadBalancerResource.ingress]);
@@ -49,31 +49,6 @@ function deploy(kubectl, manifestFilePaths, deploymentStrategy) {
     });
 }
 exports.deploy = deploy;
-function routeBlueGreen(kubectl, inputManifestFiles) {
-    return __awaiter(this, void 0, void 0, function* () {
-        // get buffer time
-        let sleepTime = parseInt(TaskInputParameters.versionSwitchBuffer);
-        //logging start of buffer time
-        let temp = new Date();
-        console.log('starting buffer time of ' + sleepTime + ' minute/s at ' + temp.getHours() + ':' + temp.getMinutes() + ':' + temp.getSeconds() + ' UTC');
-        // waiting
-        yield utility_1.sleep(sleepTime * 1000 * 60);
-        // logging end of buffer time
-        temp = new Date();
-        console.log('stopping buffer time of ' + sleepTime + ' minute/s at ' + temp.getHours() + ':' + temp.getMinutes() + ':' + temp.getSeconds() + ' UTC');
-        const manifestObjects = blue_green_helper_1.getManifestObjects(inputManifestFiles);
-        // routing to new deployments
-        if (ingress_blue_green_helper_1.isIngressRoute()) {
-            ingress_blue_green_helper_1.blueGreenRouteIngress(kubectl, blue_green_helper_1.BLUE_GREEN_NEW_LABEL_VALUE, manifestObjects.serviceNameMap, manifestObjects.serviceEntityList, manifestObjects.ingressEntityList);
-        }
-        else if (smi_blue_green_helper_1.isSMIRoute()) {
-            smi_blue_green_helper_1.blueGreenRouteTraffic(kubectl, blue_green_helper_1.BLUE_GREEN_NEW_LABEL_VALUE, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
-        }
-        else {
-            service_blue_green_helper_1.blueGreenRouteService(kubectl, blue_green_helper_1.BLUE_GREEN_NEW_LABEL_VALUE, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
-        }
-    });
-}
 function getManifestFiles(manifestFilePaths) {
     const files = utils.getManifestFiles(manifestFilePaths);
     if (files == null || files.length === 0) {
@@ -97,14 +72,14 @@ function deployManifests(files, kubectl, isCanaryDeploymentStrategy, isBlueGreen
     }
     else if (isBlueGreenDeploymentStrategy) {
         let blueGreenDeploymentOutput;
-        if (ingress_blue_green_helper_1.isIngressRoute()) {
+        if (blue_green_helper_1.isIngressRoute()) {
             blueGreenDeploymentOutput = ingress_blue_green_helper_1.deployBlueGreenIngress(kubectl, files);
         }
-        else if (smi_blue_green_helper_1.isSMIRoute()) {
+        else if (blue_green_helper_1.isSMIRoute()) {
             blueGreenDeploymentOutput = smi_blue_green_helper_1.deployBlueGreenSMI(kubectl, files);
         }
         else {
-            blueGreenDeploymentOutput = service_blue_green_helper_1.deployBlueGreen(kubectl, files);
+            blueGreenDeploymentOutput = service_blue_green_helper_1.deployBlueGreenService(kubectl, files);
         }
         result = blueGreenDeploymentOutput.result;
         files = blueGreenDeploymentOutput.newFilePaths;

--- a/lib/utilities/strategy-helpers/ingress-blue-green-helper.js
+++ b/lib/utilities/strategy-helpers/ingress-blue-green-helper.js
@@ -9,7 +9,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.updateIngressBackend = exports.getUpdatedBlueGreenIngress = exports.validateIngressesState = exports.routeBlueGreenIngress = exports.blueGreenRejectIngress = exports.promoteBlueGreenIngress = exports.deployBlueGreenIngress = void 0;
+exports.updateIngressBackend = exports.getUpdatedBlueGreenIngress = exports.validateIngressesState = exports.routeBlueGreenIngress = exports.rejectBlueGreenIngress = exports.promoteBlueGreenIngress = exports.deployBlueGreenIngress = void 0;
 const core = require("@actions/core");
 const fileHelper = require("../files-helper");
 const blue_green_helper_1 = require("./blue-green-helper");
@@ -57,7 +57,7 @@ function promoteBlueGreenIngress(kubectl, manifestObjects) {
     });
 }
 exports.promoteBlueGreenIngress = promoteBlueGreenIngress;
-function blueGreenRejectIngress(kubectl, filePaths) {
+function rejectBlueGreenIngress(kubectl, filePaths) {
     return __awaiter(this, void 0, void 0, function* () {
         // get all kubernetes objects defined in manifest files
         const manifestObjects = blue_green_helper_1.getManifestObjects(filePaths);
@@ -67,7 +67,7 @@ function blueGreenRejectIngress(kubectl, filePaths) {
         blue_green_helper_1.deleteWorkloadsAndServicesWithLabel(kubectl, blue_green_helper_2.GREEN_LABEL_VALUE, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
     });
 }
-exports.blueGreenRejectIngress = blueGreenRejectIngress;
+exports.rejectBlueGreenIngress = rejectBlueGreenIngress;
 function routeBlueGreenIngress(kubectl, nextLabel, serviceNameMap, serviceEntityList, ingressEntityList) {
     let newObjectsList = [];
     if (!nextLabel) {

--- a/lib/utilities/strategy-helpers/ingress-blue-green-helper.js
+++ b/lib/utilities/strategy-helpers/ingress-blue-green-helper.js
@@ -9,27 +9,21 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.updateIngressBackend = exports.getUpdatedBlueGreenIngress = exports.validateIngressState = exports.blueGreenRouteIngress = exports.blueGreenRejectIngress = exports.blueGreenPromoteIngress = exports.deployBlueGreenIngress = exports.isIngressRoute = void 0;
+exports.updateIngressBackend = exports.getUpdatedBlueGreenIngress = exports.validateIngressState = exports.routeBlueGreenIngress = exports.blueGreenRejectIngress = exports.blueGreenPromoteIngress = exports.deployBlueGreenIngress = void 0;
 const core = require("@actions/core");
 const fileHelper = require("../files-helper");
-const TaskInputParameters = require("../../input-parameters");
 const blue_green_helper_1 = require("./blue-green-helper");
 const blue_green_helper_2 = require("./blue-green-helper");
-const INGRESS_ROUTE = 'INGRESS';
-function isIngressRoute() {
-    const routeMethod = TaskInputParameters.routeMethod;
-    return routeMethod && routeMethod.toUpperCase() === INGRESS_ROUTE;
-}
-exports.isIngressRoute = isIngressRoute;
+const BACKEND = 'BACKEND';
 function deployBlueGreenIngress(kubectl, filePaths) {
     // get all kubernetes objects defined in manifest files
     const manifestObjects = blue_green_helper_1.getManifestObjects(filePaths);
     // create deployments with green label value
-    const result = blue_green_helper_1.createWorkloadssWithLabel(kubectl, manifestObjects.deploymentEntityList, blue_green_helper_2.BLUE_GREEN_NEW_LABEL_VALUE);
+    const result = blue_green_helper_1.createWorkloadsWithLabel(kubectl, manifestObjects.deploymentEntityList, blue_green_helper_2.BLUE_GREEN_NEW_LABEL_VALUE);
     // create new services and other objects 
     let newObjectsList = [];
     manifestObjects.serviceEntityList.forEach(inputObject => {
-        const newBlueGreenObject = blue_green_helper_1.getNewBlueGreenObject(inputObject, 0, blue_green_helper_2.BLUE_GREEN_NEW_LABEL_VALUE);
+        const newBlueGreenObject = blue_green_helper_1.getNewBlueGreenObject(inputObject, blue_green_helper_2.BLUE_GREEN_NEW_LABEL_VALUE);
         ;
         core.debug('New blue-green object is: ' + JSON.stringify(newBlueGreenObject));
         newObjectsList.push(newBlueGreenObject);
@@ -50,11 +44,11 @@ function blueGreenPromoteIngress(kubectl, manifestObjects) {
         // deleting existing stable deploymetns and services
         blue_green_helper_1.deleteWorkloadsAndServicesWithLabel(kubectl, null, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
         // create stable deployments with new configuration
-        const result = blue_green_helper_1.createWorkloadssWithLabel(kubectl, manifestObjects.deploymentEntityList, blue_green_helper_2.NONE_LABEL_VALUE);
+        const result = blue_green_helper_1.createWorkloadsWithLabel(kubectl, manifestObjects.deploymentEntityList, blue_green_helper_2.NONE_LABEL_VALUE);
         // create stable services
         const newObjectsList = [];
         manifestObjects.serviceEntityList.forEach((inputObject) => {
-            const newBlueGreenObject = blue_green_helper_1.getNewBlueGreenObject(inputObject, 0, blue_green_helper_2.NONE_LABEL_VALUE);
+            const newBlueGreenObject = blue_green_helper_1.getNewBlueGreenObject(inputObject, blue_green_helper_2.NONE_LABEL_VALUE);
             core.debug('New blue-green object is: ' + JSON.stringify(newBlueGreenObject));
             newObjectsList.push(newBlueGreenObject);
         });
@@ -70,13 +64,13 @@ function blueGreenRejectIngress(kubectl, filePaths) {
         // get all kubernetes objects defined in manifest files
         const manifestObjects = blue_green_helper_1.getManifestObjects(filePaths);
         // routing ingress to stables services
-        blueGreenRouteIngress(kubectl, null, manifestObjects.serviceNameMap, manifestObjects.serviceEntityList, manifestObjects.ingressEntityList);
+        routeBlueGreenIngress(kubectl, null, manifestObjects.serviceNameMap, manifestObjects.serviceEntityList, manifestObjects.ingressEntityList);
         // deleting green services and deployments
         blue_green_helper_1.deleteWorkloadsAndServicesWithLabel(kubectl, blue_green_helper_2.BLUE_GREEN_NEW_LABEL_VALUE, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
     });
 }
 exports.blueGreenRejectIngress = blueGreenRejectIngress;
-function blueGreenRouteIngress(kubectl, nextLabel, serviceNameMap, serviceEntityList, ingressEntityList) {
+function routeBlueGreenIngress(kubectl, nextLabel, serviceNameMap, serviceEntityList, ingressEntityList) {
     let newObjectsList = [];
     if (!nextLabel) {
         newObjectsList = newObjectsList.concat(ingressEntityList);
@@ -104,7 +98,7 @@ function blueGreenRouteIngress(kubectl, nextLabel, serviceNameMap, serviceEntity
     const manifestFiles = fileHelper.writeObjectsToFile(newObjectsList);
     kubectl.apply(manifestFiles);
 }
-exports.blueGreenRouteIngress = blueGreenRouteIngress;
+exports.routeBlueGreenIngress = routeBlueGreenIngress;
 function validateIngressState(kubectl, ingressEntityList, serviceNameMap) {
     let isIngressTargetingNewServices = true;
     ingressEntityList.forEach((inputObject) => {
@@ -149,7 +143,7 @@ function getUpdatedBlueGreenIngress(inputObject, serviceNameMap, type) {
         return inputObject;
     }
     const newObject = JSON.parse(JSON.stringify(inputObject));
-    //adding green labels and values
+    // adding green labels and values
     blue_green_helper_1.addBlueGreenLabelsAndAnnotations(newObject, type);
     // Updating ingress labels
     let finalObject = updateIngressBackend(newObject, serviceNameMap);
@@ -158,11 +152,11 @@ function getUpdatedBlueGreenIngress(inputObject, serviceNameMap, type) {
 exports.getUpdatedBlueGreenIngress = getUpdatedBlueGreenIngress;
 function updateIngressBackend(inputObject, serviceNameMap) {
     inputObject = JSON.parse(JSON.stringify(inputObject), (key, value) => {
-        if (key.toUpperCase() === 'BACKEND') {
-            let serName = value.serviceName;
-            if (serviceNameMap.has(serName)) {
-                //updating srvice name with corresponging bluegreen name only if service is provied in given manifests
-                value.serviceName = serviceNameMap.get(serName);
+        if (key.toUpperCase() === BACKEND) {
+            let serviceName = value.serviceName;
+            if (serviceNameMap.has(serviceName)) {
+                // updating service name with corresponding bluegreen name only if service is provied in given manifests
+                value.serviceName = serviceNameMap.get(serviceName);
             }
         }
         return value;

--- a/lib/utilities/strategy-helpers/ingress-blue-green-helper.js
+++ b/lib/utilities/strategy-helpers/ingress-blue-green-helper.js
@@ -9,7 +9,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.updateIngressBackend = exports.getUpdatedBlueGreenIngress = exports.validateIngressState = exports.routeBlueGreenIngress = exports.blueGreenRejectIngress = exports.blueGreenPromoteIngress = exports.deployBlueGreenIngress = void 0;
+exports.updateIngressBackend = exports.getUpdatedBlueGreenIngress = exports.validateIngressesState = exports.routeBlueGreenIngress = exports.blueGreenRejectIngress = exports.promoteBlueGreenIngress = exports.deployBlueGreenIngress = void 0;
 const core = require("@actions/core");
 const fileHelper = require("../files-helper");
 const blue_green_helper_1 = require("./blue-green-helper");
@@ -19,11 +19,11 @@ function deployBlueGreenIngress(kubectl, filePaths) {
     // get all kubernetes objects defined in manifest files
     const manifestObjects = blue_green_helper_1.getManifestObjects(filePaths);
     // create deployments with green label value
-    const result = blue_green_helper_1.createWorkloadsWithLabel(kubectl, manifestObjects.deploymentEntityList, blue_green_helper_2.BLUE_GREEN_NEW_LABEL_VALUE);
+    const result = blue_green_helper_1.createWorkloadsWithLabel(kubectl, manifestObjects.deploymentEntityList, blue_green_helper_2.GREEN_LABEL_VALUE);
     // create new services and other objects 
     let newObjectsList = [];
     manifestObjects.serviceEntityList.forEach(inputObject => {
-        const newBlueGreenObject = blue_green_helper_1.getNewBlueGreenObject(inputObject, blue_green_helper_2.BLUE_GREEN_NEW_LABEL_VALUE);
+        const newBlueGreenObject = blue_green_helper_1.getNewBlueGreenObject(inputObject, blue_green_helper_2.GREEN_LABEL_VALUE);
         ;
         core.debug('New blue-green object is: ' + JSON.stringify(newBlueGreenObject));
         newObjectsList.push(newBlueGreenObject);
@@ -35,17 +35,15 @@ function deployBlueGreenIngress(kubectl, filePaths) {
     return result;
 }
 exports.deployBlueGreenIngress = deployBlueGreenIngress;
-function blueGreenPromoteIngress(kubectl, manifestObjects) {
+function promoteBlueGreenIngress(kubectl, manifestObjects) {
     return __awaiter(this, void 0, void 0, function* () {
         //checking if anything to promote
-        if (!validateIngressState(kubectl, manifestObjects.ingressEntityList, manifestObjects.serviceNameMap)) {
+        if (!validateIngressesState(kubectl, manifestObjects.ingressEntityList, manifestObjects.serviceNameMap)) {
             throw ('NotInPromoteStateIngress');
         }
-        // deleting existing stable deploymetns and services
-        blue_green_helper_1.deleteWorkloadsAndServicesWithLabel(kubectl, null, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
         // create stable deployments with new configuration
         const result = blue_green_helper_1.createWorkloadsWithLabel(kubectl, manifestObjects.deploymentEntityList, blue_green_helper_2.NONE_LABEL_VALUE);
-        // create stable services
+        // create stable services with new configuration
         const newObjectsList = [];
         manifestObjects.serviceEntityList.forEach((inputObject) => {
             const newBlueGreenObject = blue_green_helper_1.getNewBlueGreenObject(inputObject, blue_green_helper_2.NONE_LABEL_VALUE);
@@ -58,7 +56,7 @@ function blueGreenPromoteIngress(kubectl, manifestObjects) {
         return result;
     });
 }
-exports.blueGreenPromoteIngress = blueGreenPromoteIngress;
+exports.promoteBlueGreenIngress = promoteBlueGreenIngress;
 function blueGreenRejectIngress(kubectl, filePaths) {
     return __awaiter(this, void 0, void 0, function* () {
         // get all kubernetes objects defined in manifest files
@@ -66,7 +64,7 @@ function blueGreenRejectIngress(kubectl, filePaths) {
         // routing ingress to stables services
         routeBlueGreenIngress(kubectl, null, manifestObjects.serviceNameMap, manifestObjects.serviceEntityList, manifestObjects.ingressEntityList);
         // deleting green services and deployments
-        blue_green_helper_1.deleteWorkloadsAndServicesWithLabel(kubectl, blue_green_helper_2.BLUE_GREEN_NEW_LABEL_VALUE, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
+        blue_green_helper_1.deleteWorkloadsAndServicesWithLabel(kubectl, blue_green_helper_2.GREEN_LABEL_VALUE, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
     });
 }
 exports.blueGreenRejectIngress = blueGreenRejectIngress;
@@ -77,17 +75,8 @@ function routeBlueGreenIngress(kubectl, nextLabel, serviceNameMap, serviceEntity
     }
     else {
         ingressEntityList.forEach((inputObject) => {
-            let isRouted = false;
-            // sees if ingress targets a service in the given manifests
-            JSON.parse(JSON.stringify(inputObject), (key, value) => {
-                if (key === 'serviceName' && serviceNameMap.has(value)) {
-                    isRouted = true;
-                }
-                return value;
-            });
-            // routing to green objects only if ingress is routed
-            if (isRouted) {
-                const newBlueGreenIngressObject = getUpdatedBlueGreenIngress(inputObject, serviceNameMap, blue_green_helper_2.BLUE_GREEN_NEW_LABEL_VALUE);
+            if (isIngressRouted(inputObject, serviceNameMap)) {
+                const newBlueGreenIngressObject = getUpdatedBlueGreenIngress(inputObject, serviceNameMap, blue_green_helper_2.GREEN_LABEL_VALUE);
                 newObjectsList.push(newBlueGreenIngressObject);
             }
             else {
@@ -99,18 +88,10 @@ function routeBlueGreenIngress(kubectl, nextLabel, serviceNameMap, serviceEntity
     kubectl.apply(manifestFiles);
 }
 exports.routeBlueGreenIngress = routeBlueGreenIngress;
-function validateIngressState(kubectl, ingressEntityList, serviceNameMap) {
-    let isIngressTargetingNewServices = true;
+function validateIngressesState(kubectl, ingressEntityList, serviceNameMap) {
+    let areIngressesTargetingNewServices = true;
     ingressEntityList.forEach((inputObject) => {
-        let isRouted = false;
-        // finding if ingress is targeting a service in given manifests
-        JSON.parse(JSON.stringify(inputObject), (key, value) => {
-            if (key === 'serviceName' && serviceNameMap.has(value)) {
-                isRouted = true;
-            }
-            return value;
-        });
-        if (isRouted) {
+        if (isIngressRouted(inputObject, serviceNameMap)) {
             //querying existing ingress
             let existingIngress = blue_green_helper_1.fetchResource(kubectl, inputObject.kind, inputObject.metadata.name);
             if (!!existingIngress) {
@@ -121,22 +102,33 @@ function validateIngressState(kubectl, ingressEntityList, serviceNameMap) {
                 }
                 catch (_a) {
                     // if no label exists, then not an ingress targeting green deployments
-                    isIngressTargetingNewServices = false;
+                    areIngressesTargetingNewServices = false;
                 }
-                if (currentLabel != blue_green_helper_2.BLUE_GREEN_NEW_LABEL_VALUE) {
+                if (currentLabel != blue_green_helper_2.GREEN_LABEL_VALUE) {
                     // if not green label, then wrong configuration
-                    isIngressTargetingNewServices = false;
+                    areIngressesTargetingNewServices = false;
                 }
             }
             else {
                 // no ingress at all, so nothing to promote
-                isIngressTargetingNewServices = false;
+                areIngressesTargetingNewServices = false;
             }
         }
     });
-    return isIngressTargetingNewServices;
+    return areIngressesTargetingNewServices;
 }
-exports.validateIngressState = validateIngressState;
+exports.validateIngressesState = validateIngressesState;
+function isIngressRouted(ingressObject, serviceNameMap) {
+    let isIngressRouted = false;
+    // sees if ingress targets a service in the given manifests
+    JSON.parse(JSON.stringify(ingressObject), (key, value) => {
+        if (key === 'serviceName' && serviceNameMap.has(value)) {
+            isIngressRouted = true;
+        }
+        return value;
+    });
+    return isIngressRouted;
+}
 function getUpdatedBlueGreenIngress(inputObject, serviceNameMap, type) {
     if (!type) {
         // returning original with no modifications

--- a/lib/utilities/strategy-helpers/ingress-blue-green-helper.js
+++ b/lib/utilities/strategy-helpers/ingress-blue-green-helper.js
@@ -1,0 +1,172 @@
+'use strict';
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.updateIngressBackend = exports.getUpdatedBlueGreenIngress = exports.validateIngressState = exports.blueGreenRouteIngress = exports.blueGreenRejectIngress = exports.blueGreenPromoteIngress = exports.deployBlueGreenIngress = exports.isIngressRoute = void 0;
+const core = require("@actions/core");
+const fileHelper = require("../files-helper");
+const TaskInputParameters = require("../../input-parameters");
+const blue_green_helper_1 = require("./blue-green-helper");
+const blue_green_helper_2 = require("./blue-green-helper");
+const INGRESS_ROUTE = 'INGRESS';
+function isIngressRoute() {
+    const routeMethod = TaskInputParameters.routeMethod;
+    return routeMethod && routeMethod.toUpperCase() === INGRESS_ROUTE;
+}
+exports.isIngressRoute = isIngressRoute;
+function deployBlueGreenIngress(kubectl, filePaths) {
+    // get all kubernetes objects defined in manifest files
+    const manifestObjects = blue_green_helper_1.getManifestObjects(filePaths);
+    // create deployments with green label value
+    const result = blue_green_helper_1.createWorkloadssWithLabel(kubectl, manifestObjects.deploymentEntityList, blue_green_helper_2.BLUE_GREEN_NEW_LABEL_VALUE);
+    // create new services and other objects 
+    let newObjectsList = [];
+    manifestObjects.serviceEntityList.forEach(inputObject => {
+        const newBlueGreenObject = blue_green_helper_1.getNewBlueGreenObject(inputObject, 0, blue_green_helper_2.BLUE_GREEN_NEW_LABEL_VALUE);
+        ;
+        core.debug('New blue-green object is: ' + JSON.stringify(newBlueGreenObject));
+        newObjectsList.push(newBlueGreenObject);
+    });
+    newObjectsList = newObjectsList.concat(manifestObjects.otherObjects);
+    const manifestFiles = fileHelper.writeObjectsToFile(newObjectsList);
+    kubectl.apply(manifestFiles);
+    // return results to check for manifest stability
+    return result;
+}
+exports.deployBlueGreenIngress = deployBlueGreenIngress;
+function blueGreenPromoteIngress(kubectl, manifestObjects) {
+    return __awaiter(this, void 0, void 0, function* () {
+        //checking if anything to promote
+        if (!validateIngressState(kubectl, manifestObjects.ingressEntityList, manifestObjects.serviceNameMap)) {
+            throw ('NotInPromoteStateIngress');
+        }
+        // deleting existing stable deploymetns and services
+        blue_green_helper_1.deleteWorkloadsAndServicesWithLabel(kubectl, null, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
+        // create stable deployments with new configuration
+        const result = blue_green_helper_1.createWorkloadssWithLabel(kubectl, manifestObjects.deploymentEntityList, blue_green_helper_2.NONE_LABEL_VALUE);
+        // create stable services
+        const newObjectsList = [];
+        manifestObjects.serviceEntityList.forEach((inputObject) => {
+            const newBlueGreenObject = blue_green_helper_1.getNewBlueGreenObject(inputObject, 0, blue_green_helper_2.NONE_LABEL_VALUE);
+            core.debug('New blue-green object is: ' + JSON.stringify(newBlueGreenObject));
+            newObjectsList.push(newBlueGreenObject);
+        });
+        const manifestFiles = fileHelper.writeObjectsToFile(newObjectsList);
+        kubectl.apply(manifestFiles);
+        // returning deployments to check for rollout stability
+        return result;
+    });
+}
+exports.blueGreenPromoteIngress = blueGreenPromoteIngress;
+function blueGreenRejectIngress(kubectl, filePaths) {
+    return __awaiter(this, void 0, void 0, function* () {
+        // get all kubernetes objects defined in manifest files
+        const manifestObjects = blue_green_helper_1.getManifestObjects(filePaths);
+        // routing ingress to stables services
+        blueGreenRouteIngress(kubectl, null, manifestObjects.serviceNameMap, manifestObjects.serviceEntityList, manifestObjects.ingressEntityList);
+        // deleting green services and deployments
+        blue_green_helper_1.deleteWorkloadsAndServicesWithLabel(kubectl, blue_green_helper_2.BLUE_GREEN_NEW_LABEL_VALUE, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
+    });
+}
+exports.blueGreenRejectIngress = blueGreenRejectIngress;
+function blueGreenRouteIngress(kubectl, nextLabel, serviceNameMap, serviceEntityList, ingressEntityList) {
+    let newObjectsList = [];
+    if (!nextLabel) {
+        newObjectsList = newObjectsList.concat(ingressEntityList);
+    }
+    else {
+        ingressEntityList.forEach((inputObject) => {
+            let isRouted = false;
+            // sees if ingress targets a service in the given manifests
+            JSON.parse(JSON.stringify(inputObject), (key, value) => {
+                if (key === 'serviceName' && serviceNameMap.has(value)) {
+                    isRouted = true;
+                }
+                return value;
+            });
+            // routing to green objects only if ingress is routed
+            if (isRouted) {
+                const newBlueGreenIngressObject = getUpdatedBlueGreenIngress(inputObject, serviceNameMap, blue_green_helper_2.BLUE_GREEN_NEW_LABEL_VALUE);
+                newObjectsList.push(newBlueGreenIngressObject);
+            }
+            else {
+                newObjectsList.push(inputObject);
+            }
+        });
+    }
+    const manifestFiles = fileHelper.writeObjectsToFile(newObjectsList);
+    kubectl.apply(manifestFiles);
+}
+exports.blueGreenRouteIngress = blueGreenRouteIngress;
+function validateIngressState(kubectl, ingressEntityList, serviceNameMap) {
+    let isIngressTargetingNewServices = true;
+    ingressEntityList.forEach((inputObject) => {
+        let isRouted = false;
+        // finding if ingress is targeting a service in given manifests
+        JSON.parse(JSON.stringify(inputObject), (key, value) => {
+            if (key === 'serviceName' && serviceNameMap.has(value)) {
+                isRouted = true;
+            }
+            return value;
+        });
+        if (isRouted) {
+            //querying existing ingress
+            let existingIngress = blue_green_helper_1.fetchResource(kubectl, inputObject.kind, inputObject.metadata.name);
+            if (!!existingIngress) {
+                let currentLabel;
+                // checking its label
+                try {
+                    currentLabel = existingIngress.metadata.labels[blue_green_helper_2.BLUE_GREEN_VERSION_LABEL];
+                }
+                catch (_a) {
+                    // if no label exists, then not an ingress targeting green deployments
+                    isIngressTargetingNewServices = false;
+                }
+                if (currentLabel != blue_green_helper_2.BLUE_GREEN_NEW_LABEL_VALUE) {
+                    // if not green label, then wrong configuration
+                    isIngressTargetingNewServices = false;
+                }
+            }
+            else {
+                // no ingress at all, so nothing to promote
+                isIngressTargetingNewServices = false;
+            }
+        }
+    });
+    return isIngressTargetingNewServices;
+}
+exports.validateIngressState = validateIngressState;
+function getUpdatedBlueGreenIngress(inputObject, serviceNameMap, type) {
+    if (!type) {
+        // returning original with no modifications
+        return inputObject;
+    }
+    const newObject = JSON.parse(JSON.stringify(inputObject));
+    //adding green labels and values
+    blue_green_helper_1.addBlueGreenLabelsAndAnnotations(newObject, type);
+    // Updating ingress labels
+    let finalObject = updateIngressBackend(newObject, serviceNameMap);
+    return finalObject;
+}
+exports.getUpdatedBlueGreenIngress = getUpdatedBlueGreenIngress;
+function updateIngressBackend(inputObject, serviceNameMap) {
+    inputObject = JSON.parse(JSON.stringify(inputObject), (key, value) => {
+        if (key.toUpperCase() === 'BACKEND') {
+            let serName = value.serviceName;
+            if (serviceNameMap.has(serName)) {
+                //updating srvice name with corresponging bluegreen name only if service is provied in given manifests
+                value.serviceName = serviceNameMap.get(serName);
+            }
+        }
+        return value;
+    });
+    return inputObject;
+}
+exports.updateIngressBackend = updateIngressBackend;

--- a/lib/utilities/strategy-helpers/service-blue-green-helper.js
+++ b/lib/utilities/strategy-helpers/service-blue-green-helper.js
@@ -1,0 +1,125 @@
+'use strict';
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getServiceSpecLabel = exports.validateServiceState = exports.blueGreenRouteService = exports.blueGreenReject = exports.blueGreenPromote = exports.deployBlueGreen = exports.isBlueGreenDeploymentStrategy = exports.BLUE_GREEN_DEPLOYMENT_STRATEGY = void 0;
+const fileHelper = require("../files-helper");
+const TaskInputParameters = require("../../input-parameters");
+const blue_green_helper_1 = require("./blue-green-helper");
+const blue_green_helper_2 = require("./blue-green-helper");
+exports.BLUE_GREEN_DEPLOYMENT_STRATEGY = 'BLUE-GREEN';
+function isBlueGreenDeploymentStrategy() {
+    const deploymentStrategy = TaskInputParameters.deploymentStrategy;
+    return deploymentStrategy && deploymentStrategy.toUpperCase() === exports.BLUE_GREEN_DEPLOYMENT_STRATEGY;
+}
+exports.isBlueGreenDeploymentStrategy = isBlueGreenDeploymentStrategy;
+function deployBlueGreen(kubectl, filePaths) {
+    // get all kubernetes objects defined in manifest files
+    const manifestObjects = blue_green_helper_1.getManifestObjects(filePaths);
+    // create deployments with green label value
+    const result = blue_green_helper_1.createWorkloadssWithLabel(kubectl, manifestObjects.deploymentEntityList, blue_green_helper_2.BLUE_GREEN_NEW_LABEL_VALUE);
+    // create other non deployment and non service entities
+    const newObjectsList = manifestObjects.otherObjects.concat(manifestObjects.ingressEntityList);
+    const manifestFiles = fileHelper.writeObjectsToFile(newObjectsList);
+    kubectl.apply(manifestFiles);
+    // returning deployment details to check for rollout stability
+    return result;
+}
+exports.deployBlueGreen = deployBlueGreen;
+function blueGreenPromote(kubectl, manifestObjects) {
+    return __awaiter(this, void 0, void 0, function* () {
+        // checking if services are in the right state ie. targeting green deployments
+        if (!validateServiceState(kubectl, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList)) {
+            throw ('NotInPromoteState');
+        }
+        // deleting previous stable deployments
+        blue_green_helper_1.deleteWorkloadsWithLabel(kubectl, blue_green_helper_2.NONE_LABEL_VALUE, manifestObjects.deploymentEntityList);
+        // creating stable deployments with new configurations
+        const result = blue_green_helper_1.createWorkloadssWithLabel(kubectl, manifestObjects.deploymentEntityList, blue_green_helper_2.NONE_LABEL_VALUE);
+        // returning deployment details to check for rollout stability
+        return result;
+    });
+}
+exports.blueGreenPromote = blueGreenPromote;
+function blueGreenReject(kubectl, filePaths) {
+    return __awaiter(this, void 0, void 0, function* () {
+        // get all kubernetes objects defined in manifest files
+        const manifestObjects = blue_green_helper_1.getManifestObjects(filePaths);
+        // routing to stable objects
+        blueGreenRouteService(kubectl, blue_green_helper_2.NONE_LABEL_VALUE, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
+        // seeing if we should even delete the service
+        blue_green_helper_1.cleanUp(kubectl, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
+        // deleting the new deployments with green suffix
+        blue_green_helper_1.deleteWorkloadsWithLabel(kubectl, blue_green_helper_2.BLUE_GREEN_NEW_LABEL_VALUE, manifestObjects.deploymentEntityList);
+    });
+}
+exports.blueGreenReject = blueGreenReject;
+function blueGreenRouteService(kubectl, nextLabel, deploymentEntityList, serviceEntityList) {
+    const newObjectsList = [];
+    serviceEntityList.forEach((inputObject) => {
+        let isRouted = false;
+        deploymentEntityList.forEach((depObject) => {
+            // finding if there is a deployment in the given manifests the service targets
+            if (blue_green_helper_1.getServiceSelector(inputObject) && blue_green_helper_1.getDeploymentMatchLabels(depObject) && blue_green_helper_1.getServiceSelector(inputObject) === blue_green_helper_1.getDeploymentMatchLabels(depObject)) {
+                isRouted = true;
+                // decided that this service needs to be routed
+                // point to the given nextlabel
+                const newBlueGreenServiceObject = getUpdatedBlueGreenService(inputObject, nextLabel);
+                newObjectsList.push(newBlueGreenServiceObject);
+            }
+        });
+        if (!isRouted) {
+            // if service is not routed, just push the original service
+            newObjectsList.push(inputObject);
+        }
+    });
+    // configures the services
+    const manifestFiles = fileHelper.writeObjectsToFile(newObjectsList);
+    kubectl.apply(manifestFiles);
+}
+exports.blueGreenRouteService = blueGreenRouteService;
+function getUpdatedBlueGreenService(inputObject, labelValue) {
+    const newObject = JSON.parse(JSON.stringify(inputObject));
+    // Adding labels and annotations.
+    blue_green_helper_1.addBlueGreenLabelsAndAnnotations(newObject, labelValue);
+    return newObject;
+}
+function validateServiceState(kubectl, deploymentEntityList, serviceEntityList) {
+    let isServiceTargetingNewWorkloads = true;
+    serviceEntityList.forEach((inputObject) => {
+        deploymentEntityList.forEach((depObject) => {
+            // finding out if the service is pointing to a deployment in this manifest
+            if (blue_green_helper_1.getServiceSelector(inputObject) && blue_green_helper_1.getDeploymentMatchLabels(depObject) && blue_green_helper_1.getServiceSelector(inputObject) === blue_green_helper_1.getDeploymentMatchLabels(depObject)) {
+                // finding the existing routed service
+                let existingService = blue_green_helper_1.fetchResource(kubectl, inputObject.kind, inputObject.metadata.name);
+                if (!!existingService) {
+                    let currentLabel = getServiceSpecLabel(existingService);
+                    if (currentLabel != blue_green_helper_2.BLUE_GREEN_NEW_LABEL_VALUE) {
+                        // service should be targeting deployments with green label
+                        isServiceTargetingNewWorkloads = false;
+                    }
+                }
+                else {
+                    // service targeting deployment doesn't exist
+                    isServiceTargetingNewWorkloads = false;
+                }
+            }
+        });
+    });
+    return isServiceTargetingNewWorkloads;
+}
+exports.validateServiceState = validateServiceState;
+function getServiceSpecLabel(inputObject) {
+    if (!!inputObject && inputObject.spec && inputObject.spec.selector && inputObject.spec.selector[blue_green_helper_2.BLUE_GREEN_VERSION_LABEL]) {
+        return inputObject.spec.selector[blue_green_helper_2.BLUE_GREEN_VERSION_LABEL];
+    }
+    return '';
+}
+exports.getServiceSpecLabel = getServiceSpecLabel;

--- a/lib/utilities/strategy-helpers/service-blue-green-helper.js
+++ b/lib/utilities/strategy-helpers/service-blue-green-helper.js
@@ -9,22 +9,15 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.getServiceSpecLabel = exports.validateServiceState = exports.blueGreenRouteService = exports.blueGreenReject = exports.blueGreenPromote = exports.deployBlueGreen = exports.isBlueGreenDeploymentStrategy = exports.BLUE_GREEN_DEPLOYMENT_STRATEGY = void 0;
+exports.getServiceSpecLabel = exports.validateServiceState = exports.routeBlueGreenService = exports.blueGreenReject = exports.blueGreenPromote = exports.deployBlueGreenService = void 0;
 const fileHelper = require("../files-helper");
-const TaskInputParameters = require("../../input-parameters");
 const blue_green_helper_1 = require("./blue-green-helper");
 const blue_green_helper_2 = require("./blue-green-helper");
-exports.BLUE_GREEN_DEPLOYMENT_STRATEGY = 'BLUE-GREEN';
-function isBlueGreenDeploymentStrategy() {
-    const deploymentStrategy = TaskInputParameters.deploymentStrategy;
-    return deploymentStrategy && deploymentStrategy.toUpperCase() === exports.BLUE_GREEN_DEPLOYMENT_STRATEGY;
-}
-exports.isBlueGreenDeploymentStrategy = isBlueGreenDeploymentStrategy;
-function deployBlueGreen(kubectl, filePaths) {
+function deployBlueGreenService(kubectl, filePaths) {
     // get all kubernetes objects defined in manifest files
     const manifestObjects = blue_green_helper_1.getManifestObjects(filePaths);
     // create deployments with green label value
-    const result = blue_green_helper_1.createWorkloadssWithLabel(kubectl, manifestObjects.deploymentEntityList, blue_green_helper_2.BLUE_GREEN_NEW_LABEL_VALUE);
+    const result = blue_green_helper_1.createWorkloadsWithLabel(kubectl, manifestObjects.deploymentEntityList, blue_green_helper_2.BLUE_GREEN_NEW_LABEL_VALUE);
     // create other non deployment and non service entities
     const newObjectsList = manifestObjects.otherObjects.concat(manifestObjects.ingressEntityList);
     const manifestFiles = fileHelper.writeObjectsToFile(newObjectsList);
@@ -32,7 +25,7 @@ function deployBlueGreen(kubectl, filePaths) {
     // returning deployment details to check for rollout stability
     return result;
 }
-exports.deployBlueGreen = deployBlueGreen;
+exports.deployBlueGreenService = deployBlueGreenService;
 function blueGreenPromote(kubectl, manifestObjects) {
     return __awaiter(this, void 0, void 0, function* () {
         // checking if services are in the right state ie. targeting green deployments
@@ -42,7 +35,7 @@ function blueGreenPromote(kubectl, manifestObjects) {
         // deleting previous stable deployments
         blue_green_helper_1.deleteWorkloadsWithLabel(kubectl, blue_green_helper_2.NONE_LABEL_VALUE, manifestObjects.deploymentEntityList);
         // creating stable deployments with new configurations
-        const result = blue_green_helper_1.createWorkloadssWithLabel(kubectl, manifestObjects.deploymentEntityList, blue_green_helper_2.NONE_LABEL_VALUE);
+        const result = blue_green_helper_1.createWorkloadsWithLabel(kubectl, manifestObjects.deploymentEntityList, blue_green_helper_2.NONE_LABEL_VALUE);
         // returning deployment details to check for rollout stability
         return result;
     });
@@ -53,7 +46,7 @@ function blueGreenReject(kubectl, filePaths) {
         // get all kubernetes objects defined in manifest files
         const manifestObjects = blue_green_helper_1.getManifestObjects(filePaths);
         // routing to stable objects
-        blueGreenRouteService(kubectl, blue_green_helper_2.NONE_LABEL_VALUE, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
+        routeBlueGreenService(kubectl, blue_green_helper_2.NONE_LABEL_VALUE, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
         // seeing if we should even delete the service
         blue_green_helper_1.cleanUp(kubectl, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
         // deleting the new deployments with green suffix
@@ -61,13 +54,15 @@ function blueGreenReject(kubectl, filePaths) {
     });
 }
 exports.blueGreenReject = blueGreenReject;
-function blueGreenRouteService(kubectl, nextLabel, deploymentEntityList, serviceEntityList) {
+function routeBlueGreenService(kubectl, nextLabel, deploymentEntityList, serviceEntityList) {
     const newObjectsList = [];
     serviceEntityList.forEach((inputObject) => {
         let isRouted = false;
         deploymentEntityList.forEach((depObject) => {
             // finding if there is a deployment in the given manifests the service targets
-            if (blue_green_helper_1.getServiceSelector(inputObject) && blue_green_helper_1.getDeploymentMatchLabels(depObject) && blue_green_helper_1.getServiceSelector(inputObject) === blue_green_helper_1.getDeploymentMatchLabels(depObject)) {
+            const serviceSelector = blue_green_helper_1.getServiceSelector(inputObject);
+            const matchLabels = blue_green_helper_1.getDeploymentMatchLabels(depObject);
+            if (!!serviceSelector && !!matchLabels && blue_green_helper_1.isServiceSelectorSubsetOfMatchLabel(serviceSelector, matchLabels)) {
                 isRouted = true;
                 // decided that this service needs to be routed
                 // point to the given nextlabel
@@ -84,7 +79,8 @@ function blueGreenRouteService(kubectl, nextLabel, deploymentEntityList, service
     const manifestFiles = fileHelper.writeObjectsToFile(newObjectsList);
     kubectl.apply(manifestFiles);
 }
-exports.blueGreenRouteService = blueGreenRouteService;
+exports.routeBlueGreenService = routeBlueGreenService;
+// adding green labels to configure existing service
 function getUpdatedBlueGreenService(inputObject, labelValue) {
     const newObject = JSON.parse(JSON.stringify(inputObject));
     // Adding labels and annotations.
@@ -96,7 +92,9 @@ function validateServiceState(kubectl, deploymentEntityList, serviceEntityList) 
     serviceEntityList.forEach((inputObject) => {
         deploymentEntityList.forEach((depObject) => {
             // finding out if the service is pointing to a deployment in this manifest
-            if (blue_green_helper_1.getServiceSelector(inputObject) && blue_green_helper_1.getDeploymentMatchLabels(depObject) && blue_green_helper_1.getServiceSelector(inputObject) === blue_green_helper_1.getDeploymentMatchLabels(depObject)) {
+            const serviceSelector = blue_green_helper_1.getServiceSelector(inputObject);
+            const matchLabels = blue_green_helper_1.getDeploymentMatchLabels(depObject);
+            if (!!serviceSelector && !!matchLabels && blue_green_helper_1.isServiceSelectorSubsetOfMatchLabel(serviceSelector, matchLabels)) {
                 // finding the existing routed service
                 let existingService = blue_green_helper_1.fetchResource(kubectl, inputObject.kind, inputObject.metadata.name);
                 if (!!existingService) {

--- a/lib/utilities/strategy-helpers/service-blue-green-helper.js
+++ b/lib/utilities/strategy-helpers/service-blue-green-helper.js
@@ -9,7 +9,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.getServiceSpecLabel = exports.validateServiceState = exports.routeBlueGreenService = exports.blueGreenReject = exports.blueGreenPromote = exports.deployBlueGreenService = void 0;
+exports.getServiceSpecLabel = exports.validateServicesState = exports.routeBlueGreenService = exports.blueGreenReject = exports.promoteBlueGreenService = exports.deployBlueGreenService = void 0;
 const fileHelper = require("../files-helper");
 const blue_green_helper_1 = require("./blue-green-helper");
 const blue_green_helper_2 = require("./blue-green-helper");
@@ -17,7 +17,7 @@ function deployBlueGreenService(kubectl, filePaths) {
     // get all kubernetes objects defined in manifest files
     const manifestObjects = blue_green_helper_1.getManifestObjects(filePaths);
     // create deployments with green label value
-    const result = blue_green_helper_1.createWorkloadsWithLabel(kubectl, manifestObjects.deploymentEntityList, blue_green_helper_2.BLUE_GREEN_NEW_LABEL_VALUE);
+    const result = blue_green_helper_1.createWorkloadsWithLabel(kubectl, manifestObjects.deploymentEntityList, blue_green_helper_2.GREEN_LABEL_VALUE);
     // create other non deployment and non service entities
     const newObjectsList = manifestObjects.otherObjects.concat(manifestObjects.ingressEntityList);
     const manifestFiles = fileHelper.writeObjectsToFile(newObjectsList);
@@ -26,21 +26,19 @@ function deployBlueGreenService(kubectl, filePaths) {
     return result;
 }
 exports.deployBlueGreenService = deployBlueGreenService;
-function blueGreenPromote(kubectl, manifestObjects) {
+function promoteBlueGreenService(kubectl, manifestObjects) {
     return __awaiter(this, void 0, void 0, function* () {
         // checking if services are in the right state ie. targeting green deployments
-        if (!validateServiceState(kubectl, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList)) {
+        if (!validateServicesState(kubectl, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList)) {
             throw ('NotInPromoteState');
         }
-        // deleting previous stable deployments
-        blue_green_helper_1.deleteWorkloadsWithLabel(kubectl, blue_green_helper_2.NONE_LABEL_VALUE, manifestObjects.deploymentEntityList);
         // creating stable deployments with new configurations
         const result = blue_green_helper_1.createWorkloadsWithLabel(kubectl, manifestObjects.deploymentEntityList, blue_green_helper_2.NONE_LABEL_VALUE);
         // returning deployment details to check for rollout stability
         return result;
     });
 }
-exports.blueGreenPromote = blueGreenPromote;
+exports.promoteBlueGreenService = promoteBlueGreenService;
 function blueGreenReject(kubectl, filePaths) {
     return __awaiter(this, void 0, void 0, function* () {
         // get all kubernetes objects defined in manifest files
@@ -50,29 +48,21 @@ function blueGreenReject(kubectl, filePaths) {
         // seeing if we should even delete the service
         blue_green_helper_1.cleanUp(kubectl, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
         // deleting the new deployments with green suffix
-        blue_green_helper_1.deleteWorkloadsWithLabel(kubectl, blue_green_helper_2.BLUE_GREEN_NEW_LABEL_VALUE, manifestObjects.deploymentEntityList);
+        blue_green_helper_1.deleteWorkloadsWithLabel(kubectl, blue_green_helper_2.GREEN_LABEL_VALUE, manifestObjects.deploymentEntityList);
     });
 }
 exports.blueGreenReject = blueGreenReject;
 function routeBlueGreenService(kubectl, nextLabel, deploymentEntityList, serviceEntityList) {
     const newObjectsList = [];
-    serviceEntityList.forEach((inputObject) => {
-        let isRouted = false;
-        deploymentEntityList.forEach((depObject) => {
-            // finding if there is a deployment in the given manifests the service targets
-            const serviceSelector = blue_green_helper_1.getServiceSelector(inputObject);
-            const matchLabels = blue_green_helper_1.getDeploymentMatchLabels(depObject);
-            if (!!serviceSelector && !!matchLabels && blue_green_helper_1.isServiceSelectorSubsetOfMatchLabel(serviceSelector, matchLabels)) {
-                isRouted = true;
-                // decided that this service needs to be routed
-                // point to the given nextlabel
-                const newBlueGreenServiceObject = getUpdatedBlueGreenService(inputObject, nextLabel);
-                newObjectsList.push(newBlueGreenServiceObject);
-            }
-        });
-        if (!isRouted) {
+    serviceEntityList.forEach((serviceObject) => {
+        if (blue_green_helper_1.isServiceRouted(serviceObject, deploymentEntityList)) {
+            // if service is routed, point it to given label
+            const newBlueGreenServiceObject = getUpdatedBlueGreenService(serviceObject, nextLabel);
+            newObjectsList.push(newBlueGreenServiceObject);
+        }
+        else {
             // if service is not routed, just push the original service
-            newObjectsList.push(inputObject);
+            newObjectsList.push(serviceObject);
         }
     });
     // configures the services
@@ -87,33 +77,28 @@ function getUpdatedBlueGreenService(inputObject, labelValue) {
     blue_green_helper_1.addBlueGreenLabelsAndAnnotations(newObject, labelValue);
     return newObject;
 }
-function validateServiceState(kubectl, deploymentEntityList, serviceEntityList) {
-    let isServiceTargetingNewWorkloads = true;
-    serviceEntityList.forEach((inputObject) => {
-        deploymentEntityList.forEach((depObject) => {
-            // finding out if the service is pointing to a deployment in this manifest
-            const serviceSelector = blue_green_helper_1.getServiceSelector(inputObject);
-            const matchLabels = blue_green_helper_1.getDeploymentMatchLabels(depObject);
-            if (!!serviceSelector && !!matchLabels && blue_green_helper_1.isServiceSelectorSubsetOfMatchLabel(serviceSelector, matchLabels)) {
-                // finding the existing routed service
-                let existingService = blue_green_helper_1.fetchResource(kubectl, inputObject.kind, inputObject.metadata.name);
-                if (!!existingService) {
-                    let currentLabel = getServiceSpecLabel(existingService);
-                    if (currentLabel != blue_green_helper_2.BLUE_GREEN_NEW_LABEL_VALUE) {
-                        // service should be targeting deployments with green label
-                        isServiceTargetingNewWorkloads = false;
-                    }
-                }
-                else {
-                    // service targeting deployment doesn't exist
-                    isServiceTargetingNewWorkloads = false;
+function validateServicesState(kubectl, deploymentEntityList, serviceEntityList) {
+    let areServicesGreen = true;
+    serviceEntityList.forEach((serviceObject) => {
+        if (blue_green_helper_1.isServiceRouted(serviceObject, deploymentEntityList)) {
+            // finding the existing routed service
+            const existingService = blue_green_helper_1.fetchResource(kubectl, serviceObject.kind, serviceObject.metadata.name);
+            if (!!existingService) {
+                let currentLabel = getServiceSpecLabel(existingService);
+                if (currentLabel != blue_green_helper_2.GREEN_LABEL_VALUE) {
+                    // service should be targeting deployments with green label
+                    areServicesGreen = false;
                 }
             }
-        });
+            else {
+                // service targeting deployment doesn't exist
+                areServicesGreen = false;
+            }
+        }
     });
-    return isServiceTargetingNewWorkloads;
+    return areServicesGreen;
 }
-exports.validateServiceState = validateServiceState;
+exports.validateServicesState = validateServicesState;
 function getServiceSpecLabel(inputObject) {
     if (!!inputObject && inputObject.spec && inputObject.spec.selector && inputObject.spec.selector[blue_green_helper_2.BLUE_GREEN_VERSION_LABEL]) {
         return inputObject.spec.selector[blue_green_helper_2.BLUE_GREEN_VERSION_LABEL];

--- a/lib/utilities/strategy-helpers/service-blue-green-helper.js
+++ b/lib/utilities/strategy-helpers/service-blue-green-helper.js
@@ -9,7 +9,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.getServiceSpecLabel = exports.validateServicesState = exports.routeBlueGreenService = exports.blueGreenReject = exports.promoteBlueGreenService = exports.deployBlueGreenService = void 0;
+exports.getServiceSpecLabel = exports.validateServicesState = exports.routeBlueGreenService = exports.rejectBlueGreenService = exports.promoteBlueGreenService = exports.deployBlueGreenService = void 0;
 const fileHelper = require("../files-helper");
 const blue_green_helper_1 = require("./blue-green-helper");
 const blue_green_helper_2 = require("./blue-green-helper");
@@ -39,7 +39,7 @@ function promoteBlueGreenService(kubectl, manifestObjects) {
     });
 }
 exports.promoteBlueGreenService = promoteBlueGreenService;
-function blueGreenReject(kubectl, filePaths) {
+function rejectBlueGreenService(kubectl, filePaths) {
     return __awaiter(this, void 0, void 0, function* () {
         // get all kubernetes objects defined in manifest files
         const manifestObjects = blue_green_helper_1.getManifestObjects(filePaths);
@@ -51,7 +51,7 @@ function blueGreenReject(kubectl, filePaths) {
         blue_green_helper_1.deleteWorkloadsWithLabel(kubectl, blue_green_helper_2.GREEN_LABEL_VALUE, manifestObjects.deploymentEntityList);
     });
 }
-exports.blueGreenReject = blueGreenReject;
+exports.rejectBlueGreenService = rejectBlueGreenService;
 function routeBlueGreenService(kubectl, nextLabel, deploymentEntityList, serviceEntityList) {
     const newObjectsList = [];
     serviceEntityList.forEach((serviceObject) => {

--- a/lib/utilities/strategy-helpers/smi-blue-green-helper.js
+++ b/lib/utilities/strategy-helpers/smi-blue-green-helper.js
@@ -9,25 +9,18 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.cleanSetUpSMI = exports.validateTrafficSplitState = exports.blueGreenRouteTraffic = exports.getSMIServiceResource = exports.setUpSMI = exports.blueGreenRejectSMI = exports.blueGreenPromoteSMI = exports.deployBlueGreenSMI = exports.isSMIRoute = void 0;
+exports.cleanupSMI = exports.validateTrafficSplitState = exports.routeBlueGreenSMI = exports.getSMIServiceResource = exports.setupSMI = exports.blueGreenRejectSMI = exports.blueGreenPromoteSMI = exports.deployBlueGreenSMI = void 0;
 const utility_1 = require("../utility");
 const util = require("util");
 const kubectlUtils = require("../kubectl-util");
 const fileHelper = require("../files-helper");
-const TaskInputParameters = require("../../input-parameters");
 const blue_green_helper_1 = require("./blue-green-helper");
 const blue_green_helper_2 = require("./blue-green-helper");
 let trafficSplitAPIVersion = "";
-const SMI_ROUTE = 'SMI';
 const TRAFFIC_SPLIT_OBJECT_NAME_SUFFIX = '-rollout';
 const TRAFFIC_SPLIT_OBJECT = 'TrafficSplit';
 const MIN_VAL = '0';
 const MAX_VAL = '100';
-function isSMIRoute() {
-    const routeMethod = TaskInputParameters.routeMethod;
-    return routeMethod && routeMethod.toUpperCase() === SMI_ROUTE;
-}
-exports.isSMIRoute = isSMIRoute;
 function deployBlueGreenSMI(kubectl, filePaths) {
     // get all kubernetes objects defined in manifest files
     const manifestObjects = blue_green_helper_1.getManifestObjects(filePaths);
@@ -36,9 +29,9 @@ function deployBlueGreenSMI(kubectl, filePaths) {
     const manifestFiles = fileHelper.writeObjectsToFile(newObjectsList);
     kubectl.apply(manifestFiles);
     // make extraservices and trafficsplit
-    setUpSMI(kubectl, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
+    setupSMI(kubectl, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
     // create new deloyments
-    const result = blue_green_helper_1.createWorkloadssWithLabel(kubectl, manifestObjects.deploymentEntityList, blue_green_helper_2.BLUE_GREEN_NEW_LABEL_VALUE);
+    const result = blue_green_helper_1.createWorkloadsWithLabel(kubectl, manifestObjects.deploymentEntityList, blue_green_helper_2.BLUE_GREEN_NEW_LABEL_VALUE);
     // return results to check for manifest stability
     return result;
 }
@@ -52,7 +45,7 @@ function blueGreenPromoteSMI(kubectl, manifestObjects) {
         //deleting old stable deployments
         blue_green_helper_1.deleteWorkloadsWithLabel(kubectl, blue_green_helper_2.NONE_LABEL_VALUE, manifestObjects.deploymentEntityList);
         // create stable deployments with new configuration
-        const result = blue_green_helper_1.createWorkloadssWithLabel(kubectl, manifestObjects.deploymentEntityList, blue_green_helper_2.NONE_LABEL_VALUE);
+        const result = blue_green_helper_1.createWorkloadsWithLabel(kubectl, manifestObjects.deploymentEntityList, blue_green_helper_2.NONE_LABEL_VALUE);
         // return result to check for stability
         return result;
     });
@@ -63,29 +56,31 @@ function blueGreenRejectSMI(kubectl, filePaths) {
         // get all kubernetes objects defined in manifest files
         const manifestObjects = blue_green_helper_1.getManifestObjects(filePaths);
         // routing trafficsplit to stable deploymetns
-        blueGreenRouteTraffic(kubectl, blue_green_helper_2.NONE_LABEL_VALUE, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
+        routeBlueGreenSMI(kubectl, blue_green_helper_2.NONE_LABEL_VALUE, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
         // deciding whether to delete services or not
         blue_green_helper_1.cleanUp(kubectl, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
         // deleting rejected new bluegreen deplyments 
         blue_green_helper_1.deleteWorkloadsWithLabel(kubectl, blue_green_helper_2.BLUE_GREEN_NEW_LABEL_VALUE, manifestObjects.deploymentEntityList);
         //deleting trafficsplit and extra services
-        cleanSetUpSMI(kubectl, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
+        cleanupSMI(kubectl, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
     });
 }
 exports.blueGreenRejectSMI = blueGreenRejectSMI;
-function setUpSMI(kubectl, deploymentEntityList, serviceEntityList) {
+function setupSMI(kubectl, deploymentEntityList, serviceEntityList) {
     const newObjectsList = [];
     const trafficObjectList = [];
     serviceEntityList.forEach((inputObject) => {
         deploymentEntityList.forEach((depObject) => {
             // finding out whether service targets a deployment in given manifests
-            if (blue_green_helper_1.getServiceSelector(inputObject) && blue_green_helper_1.getDeploymentMatchLabels(depObject) && blue_green_helper_1.getServiceSelector(inputObject) === blue_green_helper_1.getDeploymentMatchLabels(depObject)) {
+            const serviceSelector = blue_green_helper_1.getServiceSelector(inputObject);
+            const matchLabels = blue_green_helper_1.getDeploymentMatchLabels(depObject);
+            if (!!serviceSelector && !!matchLabels && blue_green_helper_1.isServiceSelectorSubsetOfMatchLabel(serviceSelector, matchLabels)) {
                 // decided that this service needs to be routed
                 //querying for both services
                 trafficObjectList.push(inputObject);
                 // setting up the services for trafficsplit
-                const newStableService = getSMIServiceResource(inputObject, blue_green_helper_2.STABLE_SUFFIX, 0);
-                const newGreenService = getSMIServiceResource(inputObject, blue_green_helper_2.BLUE_GREEN_SUFFIX, 0);
+                const newStableService = getSMIServiceResource(inputObject, blue_green_helper_2.STABLE_SUFFIX);
+                const newGreenService = getSMIServiceResource(inputObject, blue_green_helper_2.BLUE_GREEN_SUFFIX);
                 newObjectsList.push(newStableService);
                 newObjectsList.push(newGreenService);
             }
@@ -99,7 +94,7 @@ function setUpSMI(kubectl, deploymentEntityList, serviceEntityList) {
         createTrafficSplitObject(kubectl, inputObject.metadata.name, blue_green_helper_2.NONE_LABEL_VALUE);
     });
 }
-exports.setUpSMI = setUpSMI;
+exports.setupSMI = setupSMI;
 function createTrafficSplitObject(kubectl, name, nextLabel) {
     // getting smi spec api version 
     trafficSplitAPIVersion = kubectlUtils.getTrafficSplitAPIVersion(kubectl);
@@ -136,28 +131,30 @@ function createTrafficSplitObject(kubectl, name, nextLabel) {
         }
     }`;
     let trafficSplitObject = util.format(trafficSplitObjectJson);
-    // creaeting trafficplit object
+    // creating trafficplit object
     trafficSplitObject = fileHelper.writeManifestToFile(trafficSplitObject, TRAFFIC_SPLIT_OBJECT, blue_green_helper_1.getBlueGreenResourceName(name, TRAFFIC_SPLIT_OBJECT_NAME_SUFFIX));
     kubectl.apply(trafficSplitObject);
 }
-function getSMIServiceResource(inputObject, suffix, replicas) {
+function getSMIServiceResource(inputObject, suffix) {
     const newObject = JSON.parse(JSON.stringify(inputObject));
     if (suffix === blue_green_helper_2.STABLE_SUFFIX) {
         // adding stable suffix to service name
         newObject.metadata.name = blue_green_helper_1.getBlueGreenResourceName(inputObject.metadata.name, blue_green_helper_2.STABLE_SUFFIX);
-        return blue_green_helper_1.getNewBlueGreenObject(newObject, replicas, blue_green_helper_2.NONE_LABEL_VALUE);
+        return blue_green_helper_1.getNewBlueGreenObject(newObject, blue_green_helper_2.NONE_LABEL_VALUE);
     }
     else {
         // green label will be added for these
-        return blue_green_helper_1.getNewBlueGreenObject(newObject, replicas, blue_green_helper_2.BLUE_GREEN_NEW_LABEL_VALUE);
+        return blue_green_helper_1.getNewBlueGreenObject(newObject, blue_green_helper_2.BLUE_GREEN_NEW_LABEL_VALUE);
     }
 }
 exports.getSMIServiceResource = getSMIServiceResource;
-function blueGreenRouteTraffic(kubectl, nextLabel, deploymentEntityList, serviceEntityList) {
+function routeBlueGreenSMI(kubectl, nextLabel, deploymentEntityList, serviceEntityList) {
     serviceEntityList.forEach((inputObject) => {
         deploymentEntityList.forEach((depObject) => {
             // finding out whether service targets a deployment in given manifests
-            if (blue_green_helper_1.getServiceSelector(inputObject) && blue_green_helper_1.getDeploymentMatchLabels(depObject) && blue_green_helper_1.getServiceSelector(inputObject) === blue_green_helper_1.getDeploymentMatchLabels(depObject)) {
+            const serviceSelector = blue_green_helper_1.getServiceSelector(inputObject);
+            const matchLabels = blue_green_helper_1.getDeploymentMatchLabels(depObject);
+            if (!!serviceSelector && !!matchLabels && blue_green_helper_1.isServiceSelectorSubsetOfMatchLabel(serviceSelector, matchLabels)) {
                 // decided that this service needs to be routed
                 // point to blue green entities
                 createTrafficSplitObject(kubectl, inputObject.metadata.name, nextLabel);
@@ -165,14 +162,16 @@ function blueGreenRouteTraffic(kubectl, nextLabel, deploymentEntityList, service
         });
     });
 }
-exports.blueGreenRouteTraffic = blueGreenRouteTraffic;
+exports.routeBlueGreenSMI = routeBlueGreenSMI;
 function validateTrafficSplitState(kubectl, deploymentEntityList, serviceEntityList) {
     let isTrafficSplitInRightState = true;
     serviceEntityList.forEach((inputObject) => {
         const name = inputObject.metadata.name;
         deploymentEntityList.forEach((depObject) => {
             // seeing if given service targets a corresponding deployment in given manifest
-            if (blue_green_helper_1.getServiceSelector(inputObject) && blue_green_helper_1.getDeploymentMatchLabels(depObject) && blue_green_helper_1.getServiceSelector(inputObject) === blue_green_helper_1.getDeploymentMatchLabels(depObject)) {
+            const serviceSelector = blue_green_helper_1.getServiceSelector(inputObject);
+            const matchLabels = blue_green_helper_1.getDeploymentMatchLabels(depObject);
+            if (!!serviceSelector && !!matchLabels && blue_green_helper_1.isServiceSelectorSubsetOfMatchLabel(serviceSelector, matchLabels)) {
                 // querying existing trafficsplit object
                 let trafficSplitObject = blue_green_helper_1.fetchResource(kubectl, TRAFFIC_SPLIT_OBJECT, name + TRAFFIC_SPLIT_OBJECT_NAME_SUFFIX);
                 if (!trafficSplitObject) {
@@ -205,22 +204,24 @@ function validateTrafficSplitState(kubectl, deploymentEntityList, serviceEntityL
     return isTrafficSplitInRightState;
 }
 exports.validateTrafficSplitState = validateTrafficSplitState;
-function cleanSetUpSMI(kubectl, deploymentEntityList, serviceEntityList) {
-    const delList = [];
+function cleanupSMI(kubectl, deploymentEntityList, serviceEntityList) {
+    const deleteList = [];
     serviceEntityList.forEach((inputObject) => {
         deploymentEntityList.forEach((depObject) => {
             // finding out whether service targets a deployment in given manifests
-            if (blue_green_helper_1.getServiceSelector(inputObject) && blue_green_helper_1.getDeploymentMatchLabels(depObject) && blue_green_helper_1.getServiceSelector(inputObject) === blue_green_helper_1.getDeploymentMatchLabels(depObject)) {
-                delList.push({ name: inputObject.metadata.name + blue_green_helper_2.BLUE_GREEN_SUFFIX, kind: inputObject.kind });
-                delList.push({ name: inputObject.metadata.name + blue_green_helper_2.STABLE_SUFFIX, kind: inputObject.kind });
-                delList.push({ name: inputObject.metadata.name + TRAFFIC_SPLIT_OBJECT_NAME_SUFFIX, kind: TRAFFIC_SPLIT_OBJECT });
+            const serviceSelector = blue_green_helper_1.getServiceSelector(inputObject);
+            const matchLabels = blue_green_helper_1.getDeploymentMatchLabels(depObject);
+            if (!!serviceSelector && !!matchLabels && blue_green_helper_1.isServiceSelectorSubsetOfMatchLabel(serviceSelector, matchLabels)) {
+                deleteList.push({ name: inputObject.metadata.name + blue_green_helper_2.BLUE_GREEN_SUFFIX, kind: inputObject.kind });
+                deleteList.push({ name: inputObject.metadata.name + blue_green_helper_2.STABLE_SUFFIX, kind: inputObject.kind });
+                deleteList.push({ name: inputObject.metadata.name + TRAFFIC_SPLIT_OBJECT_NAME_SUFFIX, kind: TRAFFIC_SPLIT_OBJECT });
             }
         });
     });
     // deleting all objects
-    delList.forEach((delObject) => {
+    deleteList.forEach((deleteObject) => {
         try {
-            const result = kubectl.delete([delObject.kind, delObject.name]);
+            const result = kubectl.delete([deleteObject.kind, deleteObject.name]);
             utility_1.checkForErrors([result]);
         }
         catch (ex) {
@@ -228,4 +229,4 @@ function cleanSetUpSMI(kubectl, deploymentEntityList, serviceEntityList) {
         }
     });
 }
-exports.cleanSetUpSMI = cleanSetUpSMI;
+exports.cleanupSMI = cleanupSMI;

--- a/lib/utilities/strategy-helpers/smi-blue-green-helper.js
+++ b/lib/utilities/strategy-helpers/smi-blue-green-helper.js
@@ -9,7 +9,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.cleanupSMI = exports.validateTrafficSplitState = exports.routeBlueGreenSMI = exports.getSMIServiceResource = exports.setupSMI = exports.blueGreenRejectSMI = exports.promoteBlueGreenSMI = exports.deployBlueGreenSMI = void 0;
+exports.cleanupSMI = exports.validateTrafficSplitState = exports.routeBlueGreenSMI = exports.getSMIServiceResource = exports.setupSMI = exports.rejectBlueGreenSMI = exports.promoteBlueGreenSMI = exports.deployBlueGreenSMI = void 0;
 const kubectlUtils = require("../kubectl-util");
 const fileHelper = require("../files-helper");
 const blue_green_helper_1 = require("./blue-green-helper");
@@ -47,7 +47,7 @@ function promoteBlueGreenSMI(kubectl, manifestObjects) {
     });
 }
 exports.promoteBlueGreenSMI = promoteBlueGreenSMI;
-function blueGreenRejectSMI(kubectl, filePaths) {
+function rejectBlueGreenSMI(kubectl, filePaths) {
     return __awaiter(this, void 0, void 0, function* () {
         // get all kubernetes objects defined in manifest files
         const manifestObjects = blue_green_helper_1.getManifestObjects(filePaths);
@@ -61,7 +61,7 @@ function blueGreenRejectSMI(kubectl, filePaths) {
         cleanupSMI(kubectl, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
     });
 }
-exports.blueGreenRejectSMI = blueGreenRejectSMI;
+exports.rejectBlueGreenSMI = rejectBlueGreenSMI;
 function setupSMI(kubectl, deploymentEntityList, serviceEntityList) {
     const newObjectsList = [];
     const trafficObjectList = [];

--- a/lib/utilities/strategy-helpers/smi-blue-green-helper.js
+++ b/lib/utilities/strategy-helpers/smi-blue-green-helper.js
@@ -9,7 +9,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.cleanupSMI = exports.validateTrafficSplitState = exports.routeBlueGreenSMI = exports.getSMIServiceResource = exports.setupSMI = exports.rejectBlueGreenSMI = exports.promoteBlueGreenSMI = exports.deployBlueGreenSMI = void 0;
+exports.cleanupSMI = exports.validateTrafficSplitsState = exports.routeBlueGreenSMI = exports.getSMIServiceResource = exports.setupSMI = exports.rejectBlueGreenSMI = exports.promoteBlueGreenSMI = exports.deployBlueGreenSMI = void 0;
 const kubectlUtils = require("../kubectl-util");
 const fileHelper = require("../files-helper");
 const blue_green_helper_1 = require("./blue-green-helper");
@@ -37,7 +37,7 @@ exports.deployBlueGreenSMI = deployBlueGreenSMI;
 function promoteBlueGreenSMI(kubectl, manifestObjects) {
     return __awaiter(this, void 0, void 0, function* () {
         // checking if there is something to promote
-        if (!validateTrafficSplitState(kubectl, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList)) {
+        if (!validateTrafficSplitsState(kubectl, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList)) {
             throw ('NotInPromoteStateSMI');
         }
         // create stable deployments with new configuration
@@ -146,41 +146,37 @@ function routeBlueGreenSMI(kubectl, nextLabel, deploymentEntityList, serviceEnti
     });
 }
 exports.routeBlueGreenSMI = routeBlueGreenSMI;
-function validateTrafficSplitState(kubectl, deploymentEntityList, serviceEntityList) {
-    let isTrafficSplitInRightState = true;
+function validateTrafficSplitsState(kubectl, deploymentEntityList, serviceEntityList) {
+    let areTrafficSplitsInRightState = true;
     serviceEntityList.forEach((serviceObject) => {
         if (blue_green_helper_1.isServiceRouted(serviceObject, deploymentEntityList)) {
             const name = serviceObject.metadata.name;
             let trafficSplitObject = blue_green_helper_1.fetchResource(kubectl, TRAFFIC_SPLIT_OBJECT, blue_green_helper_1.getBlueGreenResourceName(name, TRAFFIC_SPLIT_OBJECT_NAME_SUFFIX));
             if (!trafficSplitObject) {
                 // no trafficplit exits
-                isTrafficSplitInRightState = false;
+                areTrafficSplitsInRightState = false;
             }
             trafficSplitObject = JSON.parse(JSON.stringify(trafficSplitObject));
             trafficSplitObject.spec.backends.forEach(element => {
                 // checking if trafficsplit in right state to deploy
                 if (element.service === blue_green_helper_1.getBlueGreenResourceName(name, blue_green_helper_2.GREEN_SUFFIX)) {
-                    if (element.weight == MAX_VAL) {
-                    }
-                    else {
+                    if (element.weight != MAX_VAL) {
                         // green service should have max weight
-                        isTrafficSplitInRightState = false;
+                        areTrafficSplitsInRightState = false;
                     }
                 }
                 if (element.service === blue_green_helper_1.getBlueGreenResourceName(name, blue_green_helper_2.STABLE_SUFFIX)) {
-                    if (element.weight == MIN_VAL) {
-                    }
-                    else {
+                    if (element.weight != MIN_VAL) {
                         // stable service should have 0 weight
-                        isTrafficSplitInRightState = false;
+                        areTrafficSplitsInRightState = false;
                     }
                 }
             });
         }
     });
-    return isTrafficSplitInRightState;
+    return areTrafficSplitsInRightState;
 }
-exports.validateTrafficSplitState = validateTrafficSplitState;
+exports.validateTrafficSplitsState = validateTrafficSplitsState;
 function cleanupSMI(kubectl, deploymentEntityList, serviceEntityList) {
     const deleteList = [];
     serviceEntityList.forEach((serviceObject) => {

--- a/lib/utilities/strategy-helpers/smi-blue-green-helper.js
+++ b/lib/utilities/strategy-helpers/smi-blue-green-helper.js
@@ -1,0 +1,231 @@
+'use strict';
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.cleanSetUpSMI = exports.validateTrafficSplitState = exports.blueGreenRouteTraffic = exports.getSMIServiceResource = exports.setUpSMI = exports.blueGreenRejectSMI = exports.blueGreenPromoteSMI = exports.deployBlueGreenSMI = exports.isSMIRoute = void 0;
+const utility_1 = require("../utility");
+const util = require("util");
+const kubectlUtils = require("../kubectl-util");
+const fileHelper = require("../files-helper");
+const TaskInputParameters = require("../../input-parameters");
+const blue_green_helper_1 = require("./blue-green-helper");
+const blue_green_helper_2 = require("./blue-green-helper");
+let trafficSplitAPIVersion = "";
+const SMI_ROUTE = 'SMI';
+const TRAFFIC_SPLIT_OBJECT_NAME_SUFFIX = '-rollout';
+const TRAFFIC_SPLIT_OBJECT = 'TrafficSplit';
+const MIN_VAL = '0';
+const MAX_VAL = '100';
+function isSMIRoute() {
+    const routeMethod = TaskInputParameters.routeMethod;
+    return routeMethod && routeMethod.toUpperCase() === SMI_ROUTE;
+}
+exports.isSMIRoute = isSMIRoute;
+function deployBlueGreenSMI(kubectl, filePaths) {
+    // get all kubernetes objects defined in manifest files
+    const manifestObjects = blue_green_helper_1.getManifestObjects(filePaths);
+    // creating services and other objects
+    const newObjectsList = manifestObjects.otherObjects.concat(manifestObjects.serviceEntityList).concat(manifestObjects.ingressEntityList);
+    const manifestFiles = fileHelper.writeObjectsToFile(newObjectsList);
+    kubectl.apply(manifestFiles);
+    // make extraservices and trafficsplit
+    setUpSMI(kubectl, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
+    // create new deloyments
+    const result = blue_green_helper_1.createWorkloadssWithLabel(kubectl, manifestObjects.deploymentEntityList, blue_green_helper_2.BLUE_GREEN_NEW_LABEL_VALUE);
+    // return results to check for manifest stability
+    return result;
+}
+exports.deployBlueGreenSMI = deployBlueGreenSMI;
+function blueGreenPromoteSMI(kubectl, manifestObjects) {
+    return __awaiter(this, void 0, void 0, function* () {
+        // checking if there is something to promote
+        if (!validateTrafficSplitState(kubectl, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList)) {
+            throw ('NotInPromoteStateSMI');
+        }
+        //deleting old stable deployments
+        blue_green_helper_1.deleteWorkloadsWithLabel(kubectl, blue_green_helper_2.NONE_LABEL_VALUE, manifestObjects.deploymentEntityList);
+        // create stable deployments with new configuration
+        const result = blue_green_helper_1.createWorkloadssWithLabel(kubectl, manifestObjects.deploymentEntityList, blue_green_helper_2.NONE_LABEL_VALUE);
+        // return result to check for stability
+        return result;
+    });
+}
+exports.blueGreenPromoteSMI = blueGreenPromoteSMI;
+function blueGreenRejectSMI(kubectl, filePaths) {
+    return __awaiter(this, void 0, void 0, function* () {
+        // get all kubernetes objects defined in manifest files
+        const manifestObjects = blue_green_helper_1.getManifestObjects(filePaths);
+        // routing trafficsplit to stable deploymetns
+        blueGreenRouteTraffic(kubectl, blue_green_helper_2.NONE_LABEL_VALUE, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
+        // deciding whether to delete services or not
+        blue_green_helper_1.cleanUp(kubectl, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
+        // deleting rejected new bluegreen deplyments 
+        blue_green_helper_1.deleteWorkloadsWithLabel(kubectl, blue_green_helper_2.BLUE_GREEN_NEW_LABEL_VALUE, manifestObjects.deploymentEntityList);
+        //deleting trafficsplit and extra services
+        cleanSetUpSMI(kubectl, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
+    });
+}
+exports.blueGreenRejectSMI = blueGreenRejectSMI;
+function setUpSMI(kubectl, deploymentEntityList, serviceEntityList) {
+    const newObjectsList = [];
+    const trafficObjectList = [];
+    serviceEntityList.forEach((inputObject) => {
+        deploymentEntityList.forEach((depObject) => {
+            // finding out whether service targets a deployment in given manifests
+            if (blue_green_helper_1.getServiceSelector(inputObject) && blue_green_helper_1.getDeploymentMatchLabels(depObject) && blue_green_helper_1.getServiceSelector(inputObject) === blue_green_helper_1.getDeploymentMatchLabels(depObject)) {
+                // decided that this service needs to be routed
+                //querying for both services
+                trafficObjectList.push(inputObject);
+                // setting up the services for trafficsplit
+                const newStableService = getSMIServiceResource(inputObject, blue_green_helper_2.STABLE_SUFFIX, 0);
+                const newGreenService = getSMIServiceResource(inputObject, blue_green_helper_2.BLUE_GREEN_SUFFIX, 0);
+                newObjectsList.push(newStableService);
+                newObjectsList.push(newGreenService);
+            }
+        });
+    });
+    // creating services
+    const manifestFiles = fileHelper.writeObjectsToFile(newObjectsList);
+    kubectl.apply(manifestFiles);
+    // route to stable service
+    trafficObjectList.forEach((inputObject) => {
+        createTrafficSplitObject(kubectl, inputObject.metadata.name, blue_green_helper_2.NONE_LABEL_VALUE);
+    });
+}
+exports.setUpSMI = setUpSMI;
+function createTrafficSplitObject(kubectl, name, nextLabel) {
+    // getting smi spec api version 
+    trafficSplitAPIVersion = kubectlUtils.getTrafficSplitAPIVersion(kubectl);
+    // deciding weights based on nextlabel
+    let stableWeight;
+    let greenWeight;
+    if (nextLabel === blue_green_helper_2.BLUE_GREEN_NEW_LABEL_VALUE) {
+        stableWeight = parseInt(MIN_VAL);
+        greenWeight = parseInt(MAX_VAL);
+    }
+    else {
+        stableWeight = parseInt(MAX_VAL);
+        greenWeight = parseInt(MIN_VAL);
+    }
+    //traffic split json
+    const trafficSplitObjectJson = `{
+        "apiVersion": "${trafficSplitAPIVersion}",
+        "kind": "TrafficSplit",
+        "metadata": {
+            "name": "${blue_green_helper_1.getBlueGreenResourceName(name, TRAFFIC_SPLIT_OBJECT_NAME_SUFFIX)}"
+        },
+        "spec": {
+            "service": "${name}",
+            "backends": [
+                {
+                    "service": "${blue_green_helper_1.getBlueGreenResourceName(name, blue_green_helper_2.STABLE_SUFFIX)}",
+                    "weight": ${stableWeight}
+                },
+                {
+                    "service": "${blue_green_helper_1.getBlueGreenResourceName(name, blue_green_helper_2.BLUE_GREEN_SUFFIX)}",
+                    "weight": ${greenWeight}
+                }
+            ]
+        }
+    }`;
+    let trafficSplitObject = util.format(trafficSplitObjectJson);
+    // creaeting trafficplit object
+    trafficSplitObject = fileHelper.writeManifestToFile(trafficSplitObject, TRAFFIC_SPLIT_OBJECT, blue_green_helper_1.getBlueGreenResourceName(name, TRAFFIC_SPLIT_OBJECT_NAME_SUFFIX));
+    kubectl.apply(trafficSplitObject);
+}
+function getSMIServiceResource(inputObject, suffix, replicas) {
+    const newObject = JSON.parse(JSON.stringify(inputObject));
+    if (suffix === blue_green_helper_2.STABLE_SUFFIX) {
+        // adding stable suffix to service name
+        newObject.metadata.name = blue_green_helper_1.getBlueGreenResourceName(inputObject.metadata.name, blue_green_helper_2.STABLE_SUFFIX);
+        return blue_green_helper_1.getNewBlueGreenObject(newObject, replicas, blue_green_helper_2.NONE_LABEL_VALUE);
+    }
+    else {
+        // green label will be added for these
+        return blue_green_helper_1.getNewBlueGreenObject(newObject, replicas, blue_green_helper_2.BLUE_GREEN_NEW_LABEL_VALUE);
+    }
+}
+exports.getSMIServiceResource = getSMIServiceResource;
+function blueGreenRouteTraffic(kubectl, nextLabel, deploymentEntityList, serviceEntityList) {
+    serviceEntityList.forEach((inputObject) => {
+        deploymentEntityList.forEach((depObject) => {
+            // finding out whether service targets a deployment in given manifests
+            if (blue_green_helper_1.getServiceSelector(inputObject) && blue_green_helper_1.getDeploymentMatchLabels(depObject) && blue_green_helper_1.getServiceSelector(inputObject) === blue_green_helper_1.getDeploymentMatchLabels(depObject)) {
+                // decided that this service needs to be routed
+                // point to blue green entities
+                createTrafficSplitObject(kubectl, inputObject.metadata.name, nextLabel);
+            }
+        });
+    });
+}
+exports.blueGreenRouteTraffic = blueGreenRouteTraffic;
+function validateTrafficSplitState(kubectl, deploymentEntityList, serviceEntityList) {
+    let isTrafficSplitInRightState = true;
+    serviceEntityList.forEach((inputObject) => {
+        const name = inputObject.metadata.name;
+        deploymentEntityList.forEach((depObject) => {
+            // seeing if given service targets a corresponding deployment in given manifest
+            if (blue_green_helper_1.getServiceSelector(inputObject) && blue_green_helper_1.getDeploymentMatchLabels(depObject) && blue_green_helper_1.getServiceSelector(inputObject) === blue_green_helper_1.getDeploymentMatchLabels(depObject)) {
+                // querying existing trafficsplit object
+                let trafficSplitObject = blue_green_helper_1.fetchResource(kubectl, TRAFFIC_SPLIT_OBJECT, name + TRAFFIC_SPLIT_OBJECT_NAME_SUFFIX);
+                if (!trafficSplitObject) {
+                    // no trafficplit exits
+                    isTrafficSplitInRightState = false;
+                }
+                trafficSplitObject = JSON.parse(JSON.stringify(trafficSplitObject));
+                trafficSplitObject.spec.backends.forEach(element => {
+                    // checking if trafficsplit in right state to deploy
+                    if (element.service === name + blue_green_helper_2.BLUE_GREEN_SUFFIX) {
+                        if (element.weight == MAX_VAL) {
+                        }
+                        else {
+                            // green service should have max weight
+                            isTrafficSplitInRightState = false;
+                        }
+                    }
+                    if (element.service === name + blue_green_helper_2.STABLE_SUFFIX) {
+                        if (element.weight == MIN_VAL) {
+                        }
+                        else {
+                            // stable service should have 0 weight
+                            isTrafficSplitInRightState = false;
+                        }
+                    }
+                });
+            }
+        });
+    });
+    return isTrafficSplitInRightState;
+}
+exports.validateTrafficSplitState = validateTrafficSplitState;
+function cleanSetUpSMI(kubectl, deploymentEntityList, serviceEntityList) {
+    const delList = [];
+    serviceEntityList.forEach((inputObject) => {
+        deploymentEntityList.forEach((depObject) => {
+            // finding out whether service targets a deployment in given manifests
+            if (blue_green_helper_1.getServiceSelector(inputObject) && blue_green_helper_1.getDeploymentMatchLabels(depObject) && blue_green_helper_1.getServiceSelector(inputObject) === blue_green_helper_1.getDeploymentMatchLabels(depObject)) {
+                delList.push({ name: inputObject.metadata.name + blue_green_helper_2.BLUE_GREEN_SUFFIX, kind: inputObject.kind });
+                delList.push({ name: inputObject.metadata.name + blue_green_helper_2.STABLE_SUFFIX, kind: inputObject.kind });
+                delList.push({ name: inputObject.metadata.name + TRAFFIC_SPLIT_OBJECT_NAME_SUFFIX, kind: TRAFFIC_SPLIT_OBJECT });
+            }
+        });
+    });
+    // deleting all objects
+    delList.forEach((delObject) => {
+        try {
+            const result = kubectl.delete([delObject.kind, delObject.name]);
+            utility_1.checkForErrors([result]);
+        }
+        catch (ex) {
+            // Ignore failures of delete if doesn't exist
+        }
+    });
+}
+exports.cleanSetUpSMI = cleanSetUpSMI;

--- a/lib/utilities/strategy-helpers/smi-blue-green-helper.js
+++ b/lib/utilities/strategy-helpers/smi-blue-green-helper.js
@@ -9,15 +9,13 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.cleanupSMI = exports.validateTrafficSplitState = exports.routeBlueGreenSMI = exports.getSMIServiceResource = exports.setupSMI = exports.blueGreenRejectSMI = exports.blueGreenPromoteSMI = exports.deployBlueGreenSMI = void 0;
-const utility_1 = require("../utility");
-const util = require("util");
+exports.cleanupSMI = exports.validateTrafficSplitState = exports.routeBlueGreenSMI = exports.getSMIServiceResource = exports.setupSMI = exports.blueGreenRejectSMI = exports.promoteBlueGreenSMI = exports.deployBlueGreenSMI = void 0;
 const kubectlUtils = require("../kubectl-util");
 const fileHelper = require("../files-helper");
 const blue_green_helper_1 = require("./blue-green-helper");
 const blue_green_helper_2 = require("./blue-green-helper");
 let trafficSplitAPIVersion = "";
-const TRAFFIC_SPLIT_OBJECT_NAME_SUFFIX = '-rollout';
+const TRAFFIC_SPLIT_OBJECT_NAME_SUFFIX = '-trafficsplit';
 const TRAFFIC_SPLIT_OBJECT = 'TrafficSplit';
 const MIN_VAL = '0';
 const MAX_VAL = '100';
@@ -31,26 +29,24 @@ function deployBlueGreenSMI(kubectl, filePaths) {
     // make extraservices and trafficsplit
     setupSMI(kubectl, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
     // create new deloyments
-    const result = blue_green_helper_1.createWorkloadsWithLabel(kubectl, manifestObjects.deploymentEntityList, blue_green_helper_2.BLUE_GREEN_NEW_LABEL_VALUE);
+    const result = blue_green_helper_1.createWorkloadsWithLabel(kubectl, manifestObjects.deploymentEntityList, blue_green_helper_2.GREEN_LABEL_VALUE);
     // return results to check for manifest stability
     return result;
 }
 exports.deployBlueGreenSMI = deployBlueGreenSMI;
-function blueGreenPromoteSMI(kubectl, manifestObjects) {
+function promoteBlueGreenSMI(kubectl, manifestObjects) {
     return __awaiter(this, void 0, void 0, function* () {
         // checking if there is something to promote
         if (!validateTrafficSplitState(kubectl, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList)) {
             throw ('NotInPromoteStateSMI');
         }
-        //deleting old stable deployments
-        blue_green_helper_1.deleteWorkloadsWithLabel(kubectl, blue_green_helper_2.NONE_LABEL_VALUE, manifestObjects.deploymentEntityList);
         // create stable deployments with new configuration
         const result = blue_green_helper_1.createWorkloadsWithLabel(kubectl, manifestObjects.deploymentEntityList, blue_green_helper_2.NONE_LABEL_VALUE);
         // return result to check for stability
         return result;
     });
 }
-exports.blueGreenPromoteSMI = blueGreenPromoteSMI;
+exports.promoteBlueGreenSMI = promoteBlueGreenSMI;
 function blueGreenRejectSMI(kubectl, filePaths) {
     return __awaiter(this, void 0, void 0, function* () {
         // get all kubernetes objects defined in manifest files
@@ -60,7 +56,7 @@ function blueGreenRejectSMI(kubectl, filePaths) {
         // deciding whether to delete services or not
         blue_green_helper_1.cleanUp(kubectl, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
         // deleting rejected new bluegreen deplyments 
-        blue_green_helper_1.deleteWorkloadsWithLabel(kubectl, blue_green_helper_2.BLUE_GREEN_NEW_LABEL_VALUE, manifestObjects.deploymentEntityList);
+        blue_green_helper_1.deleteWorkloadsWithLabel(kubectl, blue_green_helper_2.GREEN_LABEL_VALUE, manifestObjects.deploymentEntityList);
         //deleting trafficsplit and extra services
         cleanupSMI(kubectl, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
     });
@@ -69,22 +65,16 @@ exports.blueGreenRejectSMI = blueGreenRejectSMI;
 function setupSMI(kubectl, deploymentEntityList, serviceEntityList) {
     const newObjectsList = [];
     const trafficObjectList = [];
-    serviceEntityList.forEach((inputObject) => {
-        deploymentEntityList.forEach((depObject) => {
-            // finding out whether service targets a deployment in given manifests
-            const serviceSelector = blue_green_helper_1.getServiceSelector(inputObject);
-            const matchLabels = blue_green_helper_1.getDeploymentMatchLabels(depObject);
-            if (!!serviceSelector && !!matchLabels && blue_green_helper_1.isServiceSelectorSubsetOfMatchLabel(serviceSelector, matchLabels)) {
-                // decided that this service needs to be routed
-                //querying for both services
-                trafficObjectList.push(inputObject);
-                // setting up the services for trafficsplit
-                const newStableService = getSMIServiceResource(inputObject, blue_green_helper_2.STABLE_SUFFIX);
-                const newGreenService = getSMIServiceResource(inputObject, blue_green_helper_2.BLUE_GREEN_SUFFIX);
-                newObjectsList.push(newStableService);
-                newObjectsList.push(newGreenService);
-            }
-        });
+    serviceEntityList.forEach((serviceObject) => {
+        if (blue_green_helper_1.isServiceRouted(serviceObject, deploymentEntityList)) {
+            // create a trafficsplit for service
+            trafficObjectList.push(serviceObject);
+            // setting up the services for trafficsplit
+            const newStableService = getSMIServiceResource(serviceObject, blue_green_helper_2.STABLE_SUFFIX);
+            const newGreenService = getSMIServiceResource(serviceObject, blue_green_helper_2.GREEN_SUFFIX);
+            newObjectsList.push(newStableService);
+            newObjectsList.push(newGreenService);
+        }
     });
     // creating services
     const manifestFiles = fileHelper.writeObjectsToFile(newObjectsList);
@@ -101,7 +91,7 @@ function createTrafficSplitObject(kubectl, name, nextLabel) {
     // deciding weights based on nextlabel
     let stableWeight;
     let greenWeight;
-    if (nextLabel === blue_green_helper_2.BLUE_GREEN_NEW_LABEL_VALUE) {
+    if (nextLabel === blue_green_helper_2.GREEN_LABEL_VALUE) {
         stableWeight = parseInt(MIN_VAL);
         greenWeight = parseInt(MAX_VAL);
     }
@@ -110,7 +100,7 @@ function createTrafficSplitObject(kubectl, name, nextLabel) {
         greenWeight = parseInt(MIN_VAL);
     }
     //traffic split json
-    const trafficSplitObjectJson = `{
+    const trafficSplitObject = `{
         "apiVersion": "${trafficSplitAPIVersion}",
         "kind": "TrafficSplit",
         "metadata": {
@@ -124,16 +114,15 @@ function createTrafficSplitObject(kubectl, name, nextLabel) {
                     "weight": ${stableWeight}
                 },
                 {
-                    "service": "${blue_green_helper_1.getBlueGreenResourceName(name, blue_green_helper_2.BLUE_GREEN_SUFFIX)}",
+                    "service": "${blue_green_helper_1.getBlueGreenResourceName(name, blue_green_helper_2.GREEN_SUFFIX)}",
                     "weight": ${greenWeight}
                 }
             ]
         }
     }`;
-    let trafficSplitObject = util.format(trafficSplitObjectJson);
     // creating trafficplit object
-    trafficSplitObject = fileHelper.writeManifestToFile(trafficSplitObject, TRAFFIC_SPLIT_OBJECT, blue_green_helper_1.getBlueGreenResourceName(name, TRAFFIC_SPLIT_OBJECT_NAME_SUFFIX));
-    kubectl.apply(trafficSplitObject);
+    const trafficSplitManifestFile = fileHelper.writeManifestToFile(trafficSplitObject, TRAFFIC_SPLIT_OBJECT, blue_green_helper_1.getBlueGreenResourceName(name, TRAFFIC_SPLIT_OBJECT_NAME_SUFFIX));
+    kubectl.apply(trafficSplitManifestFile);
 }
 function getSMIServiceResource(inputObject, suffix) {
     const newObject = JSON.parse(JSON.stringify(inputObject));
@@ -144,89 +133,64 @@ function getSMIServiceResource(inputObject, suffix) {
     }
     else {
         // green label will be added for these
-        return blue_green_helper_1.getNewBlueGreenObject(newObject, blue_green_helper_2.BLUE_GREEN_NEW_LABEL_VALUE);
+        return blue_green_helper_1.getNewBlueGreenObject(newObject, blue_green_helper_2.GREEN_LABEL_VALUE);
     }
 }
 exports.getSMIServiceResource = getSMIServiceResource;
 function routeBlueGreenSMI(kubectl, nextLabel, deploymentEntityList, serviceEntityList) {
-    serviceEntityList.forEach((inputObject) => {
-        deploymentEntityList.forEach((depObject) => {
-            // finding out whether service targets a deployment in given manifests
-            const serviceSelector = blue_green_helper_1.getServiceSelector(inputObject);
-            const matchLabels = blue_green_helper_1.getDeploymentMatchLabels(depObject);
-            if (!!serviceSelector && !!matchLabels && blue_green_helper_1.isServiceSelectorSubsetOfMatchLabel(serviceSelector, matchLabels)) {
-                // decided that this service needs to be routed
-                // point to blue green entities
-                createTrafficSplitObject(kubectl, inputObject.metadata.name, nextLabel);
-            }
-        });
+    serviceEntityList.forEach((serviceObject) => {
+        if (blue_green_helper_1.isServiceRouted(serviceObject, deploymentEntityList)) {
+            // routing trafficsplit to given label
+            createTrafficSplitObject(kubectl, serviceObject.metadata.name, nextLabel);
+        }
     });
 }
 exports.routeBlueGreenSMI = routeBlueGreenSMI;
 function validateTrafficSplitState(kubectl, deploymentEntityList, serviceEntityList) {
     let isTrafficSplitInRightState = true;
-    serviceEntityList.forEach((inputObject) => {
-        const name = inputObject.metadata.name;
-        deploymentEntityList.forEach((depObject) => {
-            // seeing if given service targets a corresponding deployment in given manifest
-            const serviceSelector = blue_green_helper_1.getServiceSelector(inputObject);
-            const matchLabels = blue_green_helper_1.getDeploymentMatchLabels(depObject);
-            if (!!serviceSelector && !!matchLabels && blue_green_helper_1.isServiceSelectorSubsetOfMatchLabel(serviceSelector, matchLabels)) {
-                // querying existing trafficsplit object
-                let trafficSplitObject = blue_green_helper_1.fetchResource(kubectl, TRAFFIC_SPLIT_OBJECT, name + TRAFFIC_SPLIT_OBJECT_NAME_SUFFIX);
-                if (!trafficSplitObject) {
-                    // no trafficplit exits
-                    isTrafficSplitInRightState = false;
-                }
-                trafficSplitObject = JSON.parse(JSON.stringify(trafficSplitObject));
-                trafficSplitObject.spec.backends.forEach(element => {
-                    // checking if trafficsplit in right state to deploy
-                    if (element.service === name + blue_green_helper_2.BLUE_GREEN_SUFFIX) {
-                        if (element.weight == MAX_VAL) {
-                        }
-                        else {
-                            // green service should have max weight
-                            isTrafficSplitInRightState = false;
-                        }
-                    }
-                    if (element.service === name + blue_green_helper_2.STABLE_SUFFIX) {
-                        if (element.weight == MIN_VAL) {
-                        }
-                        else {
-                            // stable service should have 0 weight
-                            isTrafficSplitInRightState = false;
-                        }
-                    }
-                });
+    serviceEntityList.forEach((serviceObject) => {
+        if (blue_green_helper_1.isServiceRouted(serviceObject, deploymentEntityList)) {
+            const name = serviceObject.metadata.name;
+            let trafficSplitObject = blue_green_helper_1.fetchResource(kubectl, TRAFFIC_SPLIT_OBJECT, blue_green_helper_1.getBlueGreenResourceName(name, TRAFFIC_SPLIT_OBJECT_NAME_SUFFIX));
+            if (!trafficSplitObject) {
+                // no trafficplit exits
+                isTrafficSplitInRightState = false;
             }
-        });
+            trafficSplitObject = JSON.parse(JSON.stringify(trafficSplitObject));
+            trafficSplitObject.spec.backends.forEach(element => {
+                // checking if trafficsplit in right state to deploy
+                if (element.service === blue_green_helper_1.getBlueGreenResourceName(name, blue_green_helper_2.GREEN_SUFFIX)) {
+                    if (element.weight == MAX_VAL) {
+                    }
+                    else {
+                        // green service should have max weight
+                        isTrafficSplitInRightState = false;
+                    }
+                }
+                if (element.service === blue_green_helper_1.getBlueGreenResourceName(name, blue_green_helper_2.STABLE_SUFFIX)) {
+                    if (element.weight == MIN_VAL) {
+                    }
+                    else {
+                        // stable service should have 0 weight
+                        isTrafficSplitInRightState = false;
+                    }
+                }
+            });
+        }
     });
     return isTrafficSplitInRightState;
 }
 exports.validateTrafficSplitState = validateTrafficSplitState;
 function cleanupSMI(kubectl, deploymentEntityList, serviceEntityList) {
     const deleteList = [];
-    serviceEntityList.forEach((inputObject) => {
-        deploymentEntityList.forEach((depObject) => {
-            // finding out whether service targets a deployment in given manifests
-            const serviceSelector = blue_green_helper_1.getServiceSelector(inputObject);
-            const matchLabels = blue_green_helper_1.getDeploymentMatchLabels(depObject);
-            if (!!serviceSelector && !!matchLabels && blue_green_helper_1.isServiceSelectorSubsetOfMatchLabel(serviceSelector, matchLabels)) {
-                deleteList.push({ name: inputObject.metadata.name + blue_green_helper_2.BLUE_GREEN_SUFFIX, kind: inputObject.kind });
-                deleteList.push({ name: inputObject.metadata.name + blue_green_helper_2.STABLE_SUFFIX, kind: inputObject.kind });
-                deleteList.push({ name: inputObject.metadata.name + TRAFFIC_SPLIT_OBJECT_NAME_SUFFIX, kind: TRAFFIC_SPLIT_OBJECT });
-            }
-        });
+    serviceEntityList.forEach((serviceObject) => {
+        if (blue_green_helper_1.isServiceRouted(serviceObject, deploymentEntityList)) {
+            deleteList.push({ name: blue_green_helper_1.getBlueGreenResourceName(serviceObject.metadata.name, blue_green_helper_2.GREEN_SUFFIX), kind: serviceObject.kind });
+            deleteList.push({ name: blue_green_helper_1.getBlueGreenResourceName(serviceObject.metadata.name, blue_green_helper_2.STABLE_SUFFIX), kind: serviceObject.kind });
+            deleteList.push({ name: blue_green_helper_1.getBlueGreenResourceName(serviceObject.metadata.name, TRAFFIC_SPLIT_OBJECT_NAME_SUFFIX), kind: TRAFFIC_SPLIT_OBJECT });
+        }
     });
     // deleting all objects
-    deleteList.forEach((deleteObject) => {
-        try {
-            const result = kubectl.delete([deleteObject.kind, deleteObject.name]);
-            utility_1.checkForErrors([result]);
-        }
-        catch (ex) {
-            // Ignore failures of delete if doesn't exist
-        }
-    });
+    blue_green_helper_1.deleteObjects(kubectl, deleteList);
 }
 exports.cleanupSMI = cleanupSMI;

--- a/src/actions/promote.ts
+++ b/src/actions/promote.ts
@@ -1,22 +1,35 @@
 'use strict';
 import * as core from '@actions/core';
-
 import * as deploymentHelper from '../utilities/strategy-helpers/deployment-helper';
 import * as canaryDeploymentHelper from '../utilities/strategy-helpers/canary-deployment-helper';
 import * as SMICanaryDeploymentHelper from '../utilities/strategy-helpers/smi-canary-deployment-helper';
 import * as utils from '../utilities/manifest-utilities';
 import * as TaskInputParameters from '../input-parameters';
+import { getUpdatedManifestFiles } from '../utilities/manifest-utilities'
+import * as KubernetesObjectUtility from '../utilities/resource-object-utility';
+import * as models from '../constants';
+import * as KubernetesManifestUtility from '../utilities/manifest-stability-utility';
+import { getManifestObjects, deleteWorkloadsWithLabel, deleteWorkloadsAndServicesWithLabel } from '../utilities/strategy-helpers/blue-green-helper';
+import { BLUE_GREEN_NEW_LABEL_VALUE, NONE_LABEL_VALUE } from '../utilities/strategy-helpers/blue-green-helper';
+import { isBlueGreenDeploymentStrategy, blueGreenRouteService, blueGreenPromote } from '../utilities/strategy-helpers/service-blue-green-helper';
+import { isIngressRoute, blueGreenRouteIngress, blueGreenPromoteIngress } from '../utilities/strategy-helpers/ingress-blue-green-helper';
+import { isSMIRoute, blueGreenRouteTraffic, blueGreenPromoteSMI, cleanSetUpSMI } from '../utilities/strategy-helpers/smi-blue-green-helper';
+import { Kubectl, Resource } from '../kubectl-object-model';
 
-import { Kubectl } from '../kubectl-object-model';
+export async function promote() {
+    const kubectl = new Kubectl(await utils.getKubectl(), TaskInputParameters.namespace, true);
 
-export async function promote(ignoreSslErrors?: boolean) {
-    const kubectl = new Kubectl(await utils.getKubectl(), TaskInputParameters.namespace, ignoreSslErrors);
-
-    if (!canaryDeploymentHelper.isCanaryDeploymentStrategy()) {
-        core.debug('Strategy is not canary deployment. Invalid request.');
+    if (canaryDeploymentHelper.isCanaryDeploymentStrategy()) {
+        await promoteCanary(kubectl);
+    } else if (isBlueGreenDeploymentStrategy()) {
+        await promoteBlueGreen(kubectl);
+    } else {
+        core.debug('Strategy is not canary or blue-green deployment. Invalid request.');
         throw ('InvalidPromotetActionDeploymentStrategy');
     }
+}
 
+async function promoteCanary(kubectl: Kubectl) {
     let includeServices = false;
     if (canaryDeploymentHelper.isSMICanaryStrategy()) {
         includeServices = true;
@@ -40,5 +53,40 @@ export async function promote(ignoreSslErrors?: boolean) {
         canaryDeploymentHelper.deleteCanaryDeployment(kubectl, TaskInputParameters.manifests, includeServices);
     } catch (ex) {
         core.warning('Exception occurred while deleting canary and baseline workloads. Exception: ' + ex);
+    }
+}
+
+async function promoteBlueGreen(kubectl: Kubectl) {
+    // updated container images and pull secrets
+    let inputManifestFiles: string[] = getUpdatedManifestFiles(TaskInputParameters.manifests);
+    const manifestObjects = getManifestObjects(inputManifestFiles);
+
+    core.debug('deleting old deployment and making new ones');
+    let result;
+    if(isIngressRoute()) {
+        result = await blueGreenPromoteIngress(kubectl, manifestObjects);
+    } else if (isSMIRoute()) {
+        result = await blueGreenPromoteSMI(kubectl, manifestObjects);
+    } else {
+        result = await blueGreenPromote(kubectl, manifestObjects);
+    }
+
+    // checking stability of newly created deployments 
+    const deployedManifestFiles = result.newFilePaths;
+    const resourceTypes: Resource[] = KubernetesObjectUtility.getResources(deployedManifestFiles, models.deploymentTypes.concat([models.DiscoveryAndLoadBalancerResource.service]));
+    await KubernetesManifestUtility.checkManifestStability(kubectl, resourceTypes);
+    
+    core.debug('routing to new deployments');
+    await KubernetesManifestUtility.checkManifestStability(kubectl, resourceTypes);
+    if(isIngressRoute()) {
+        blueGreenRouteIngress(kubectl, null, manifestObjects.serviceNameMap, manifestObjects.serviceEntityList, manifestObjects.ingressEntityList);
+        deleteWorkloadsAndServicesWithLabel(kubectl, BLUE_GREEN_NEW_LABEL_VALUE, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
+    } else if (isSMIRoute()) {
+        blueGreenRouteTraffic(kubectl, NONE_LABEL_VALUE, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
+        deleteWorkloadsWithLabel(kubectl, BLUE_GREEN_NEW_LABEL_VALUE, manifestObjects.deploymentEntityList);
+        cleanSetUpSMI(kubectl, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);    
+    } else {
+        blueGreenRouteService(kubectl, NONE_LABEL_VALUE, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
+        deleteWorkloadsWithLabel(kubectl, BLUE_GREEN_NEW_LABEL_VALUE, manifestObjects.deploymentEntityList);
     }
 }

--- a/src/actions/reject.ts
+++ b/src/actions/reject.ts
@@ -5,9 +5,10 @@ import * as SMICanaryDeploymentHelper from '../utilities/strategy-helpers/smi-ca
 import { Kubectl } from '../kubectl-object-model';
 import * as utils from '../utilities/manifest-utilities';
 import * as TaskInputParameters from '../input-parameters';
-import { isBlueGreenDeploymentStrategy, blueGreenReject } from '../utilities/strategy-helpers/service-blue-green-helper';
-import { isIngressRoute ,blueGreenRejectIngress } from '../utilities/strategy-helpers/ingress-blue-green-helper';
-import { isSMIRoute, blueGreenRejectSMI} from '../utilities/strategy-helpers/smi-blue-green-helper'
+import { blueGreenReject } from '../utilities/strategy-helpers/service-blue-green-helper';
+import { blueGreenRejectIngress } from '../utilities/strategy-helpers/ingress-blue-green-helper';
+import { blueGreenRejectSMI} from '../utilities/strategy-helpers/smi-blue-green-helper'
+import { isSMIRoute, isIngressRoute, isBlueGreenDeploymentStrategy } from '../utilities/strategy-helpers/blue-green-helper'
 import { getManifestFiles } from '../utilities/strategy-helpers/deployment-helper'
 
 export async function reject() {

--- a/src/actions/reject.ts
+++ b/src/actions/reject.ts
@@ -5,9 +5,9 @@ import * as SMICanaryDeploymentHelper from '../utilities/strategy-helpers/smi-ca
 import { Kubectl } from '../kubectl-object-model';
 import * as utils from '../utilities/manifest-utilities';
 import * as TaskInputParameters from '../input-parameters';
-import { blueGreenReject } from '../utilities/strategy-helpers/service-blue-green-helper';
-import { blueGreenRejectIngress } from '../utilities/strategy-helpers/ingress-blue-green-helper';
-import { blueGreenRejectSMI} from '../utilities/strategy-helpers/smi-blue-green-helper'
+import { rejectBlueGreenService } from '../utilities/strategy-helpers/service-blue-green-helper';
+import { rejectBlueGreenIngress } from '../utilities/strategy-helpers/ingress-blue-green-helper';
+import { rejectBlueGreenSMI } from '../utilities/strategy-helpers/smi-blue-green-helper'
 import { isSMIRoute, isIngressRoute, isBlueGreenDeploymentStrategy } from '../utilities/strategy-helpers/blue-green-helper'
 import { getManifestFiles } from '../utilities/strategy-helpers/deployment-helper'
 
@@ -39,10 +39,10 @@ async function rejectCanary(kubectl: Kubectl) {
 async function rejectBlueGreen(kubectl: Kubectl) {
     let inputManifestFiles: string[] = getManifestFiles(TaskInputParameters.manifests);
     if(isIngressRoute()) {
-        await blueGreenRejectIngress(kubectl, inputManifestFiles);
+        await rejectBlueGreenIngress(kubectl, inputManifestFiles);
     } else if (isSMIRoute()) {
-        await blueGreenRejectSMI(kubectl, inputManifestFiles);
+        await rejectBlueGreenSMI(kubectl, inputManifestFiles);
     } else {
-        await blueGreenReject(kubectl, inputManifestFiles);
+        await rejectBlueGreenService(kubectl, inputManifestFiles);
     }
 }

--- a/src/actions/reject.ts
+++ b/src/actions/reject.ts
@@ -5,15 +5,25 @@ import * as SMICanaryDeploymentHelper from '../utilities/strategy-helpers/smi-ca
 import { Kubectl } from '../kubectl-object-model';
 import * as utils from '../utilities/manifest-utilities';
 import * as TaskInputParameters from '../input-parameters';
+import { isBlueGreenDeploymentStrategy, blueGreenReject } from '../utilities/strategy-helpers/service-blue-green-helper';
+import { isIngressRoute ,blueGreenRejectIngress } from '../utilities/strategy-helpers/ingress-blue-green-helper';
+import { isSMIRoute, blueGreenRejectSMI} from '../utilities/strategy-helpers/smi-blue-green-helper'
+import { getManifestFiles } from '../utilities/strategy-helpers/deployment-helper'
 
-export async function reject(ignoreSslErrors?: boolean) {
-    const kubectl = new Kubectl(await utils.getKubectl(), TaskInputParameters.namespace, ignoreSslErrors);
+export async function reject() {
+    const kubectl = new Kubectl(await utils.getKubectl(), TaskInputParameters.namespace, true);
 
-    if (!canaryDeploymentHelper.isCanaryDeploymentStrategy()) {
-        core.debug('Strategy is not canary deployment. Invalid request.');
-        throw ('InvalidRejectActionDeploymentStrategy');
+    if (canaryDeploymentHelper.isCanaryDeploymentStrategy()) {
+        await rejectCanary(kubectl);
+    } else if (isBlueGreenDeploymentStrategy()) {
+        await rejectBlueGreen(kubectl);
+    } else {
+        core.debug('Strategy is not canary or blue-green deployment. Invalid request.');
+        throw ('InvalidDeletetActionDeploymentStrategy');
     }
+}
 
+async function rejectCanary(kubectl: Kubectl) {
     let includeServices = false;
     if (canaryDeploymentHelper.isSMICanaryStrategy()) {
         core.debug('Reject deployment with SMI canary strategy');
@@ -23,4 +33,15 @@ export async function reject(ignoreSslErrors?: boolean) {
 
     core.debug('Deployment strategy selected is Canary. Deleting baseline and canary workloads.');
     canaryDeploymentHelper.deleteCanaryDeployment(kubectl, TaskInputParameters.manifests, includeServices);
+}
+
+async function rejectBlueGreen(kubectl: Kubectl) {
+    let inputManifestFiles: string[] = getManifestFiles(TaskInputParameters.manifests);
+    if(isIngressRoute()) {
+        await blueGreenRejectIngress(kubectl, inputManifestFiles);
+    } else if (isSMIRoute()) {
+        await blueGreenRejectSMI(kubectl, inputManifestFiles);
+    } else {
+        await blueGreenReject(kubectl, inputManifestFiles);
+    }
 }

--- a/src/input-parameters.ts
+++ b/src/input-parameters.ts
@@ -9,6 +9,8 @@ export const manifests = core.getInput('manifests').split('\n');
 export const canaryPercentage: string = core.getInput('percentage');
 export const deploymentStrategy: string = core.getInput('strategy');
 export const trafficSplitMethod: string = core.getInput('traffic-split-method');
+export const routeMethod: string = core.getInput('route-method');
+export const versionSwitchBuffer: string = core.getInput('version-switch-buffer');
 export const baselineAndCanaryReplicas: string = core.getInput('baseline-and-canary-replicas');
 export const args: string = core.getInput('arguments');
 export const forceDeployment: boolean = core.getInput('force').toLowerCase() == 'true';
@@ -37,5 +39,16 @@ try {
     }
 } catch (ex) {
     core.setFailed("Enter a valid 'baseline-and-canary-replicas' integer value");
+    process.exit(1);
+}
+
+try {
+    const pe = parseInt(versionSwitchBuffer);
+    if (pe < 0 || pe > 300) {
+        core.setFailed('Invalid buffer time, valid version-switch-buffer is a value more than or equal to 0 and lesser than or equal 300');
+        process.exit(1);
+    }
+} catch (ex) {
+    core.setFailed("Enter a valid 'version-switch-buffer' integer value");
     process.exit(1);
 }

--- a/src/run.ts
+++ b/src/run.ts
@@ -67,10 +67,10 @@ export async function run() {
         await deploy(new Kubectl(kubectlPath, namespace), manifests, strategy);
     }
     else if (action === 'promote') {
-        await promote(true);
+        await promote();
     }
     else if (action === 'reject') {
-        await reject(true);
+        await reject();
     }
     else {
         core.setFailed('Not a valid action. The allowed actions are deploy, promote, reject');

--- a/src/utilities/resource-object-utility.ts
+++ b/src/utilities/resource-object-utility.ts
@@ -5,6 +5,7 @@ import * as yaml from 'js-yaml';
 import { Resource } from '../kubectl-object-model';
 import { KubernetesWorkload, deploymentTypes, workloadTypes } from '../constants';
 import { StringComparer, isEqual } from './string-comparison';
+const INGRESS = "Ingress";
 
 export function isDeploymentEntity(kind: string): boolean {
     if (!kind) {
@@ -39,7 +40,7 @@ export function isIngressEntity(kind: string): boolean {
         throw('ResourceKindNotDefined');
     }
 
-    return isEqual("Ingress", kind, StringComparer.OrdinalIgnoreCase);
+    return isEqual(INGRESS, kind, StringComparer.OrdinalIgnoreCase);
 }
 
 export function getReplicaCount(inputObject: any): any {

--- a/src/utilities/resource-object-utility.ts
+++ b/src/utilities/resource-object-utility.ts
@@ -34,6 +34,14 @@ export function isServiceEntity(kind: string): boolean {
     return isEqual("Service", kind, StringComparer.OrdinalIgnoreCase);
 }
 
+export function isIngressEntity(kind: string): boolean {
+    if (!kind) {
+        throw('ResourceKindNotDefined');
+    }
+
+    return isEqual("Ingress", kind, StringComparer.OrdinalIgnoreCase);
+}
+
 export function getReplicaCount(inputObject: any): any {
     if (!inputObject) {
         throw ('NullInputObject');

--- a/src/utilities/strategy-helpers/blue-green-helper.ts
+++ b/src/utilities/strategy-helpers/blue-green-helper.ts
@@ -3,21 +3,67 @@
 import * as core from '@actions/core';
 import * as fs from 'fs';
 import * as yaml from 'js-yaml';
-import { checkForErrors } from '../utility';
+import { checkForErrors, sleep } from '../utility';
 import { Kubectl } from '../../kubectl-object-model';
 import { KubernetesWorkload } from '../../constants';
 import { StringComparer, isEqual } from '../string-comparison';
 import * as fileHelper from '../files-helper';
 import * as helper from '../resource-object-utility';
+import * as TaskInputParameters from '../../input-parameters';
+import { routeBlueGreenService } from './service-blue-green-helper';
+import { routeBlueGreenIngress } from './ingress-blue-green-helper';
+import { routeBlueGreenSMI } from './smi-blue-green-helper';
 
+export const BLUE_GREEN_DEPLOYMENT_STRATEGY = 'BLUE-GREEN';
 export const BLUE_GREEN_NEW_LABEL_VALUE = 'green';
 export const NONE_LABEL_VALUE = 'None';
 export const BLUE_GREEN_VERSION_LABEL = 'k8s.deploy.color';
 export const BLUE_GREEN_SUFFIX = '-green';
 export const STABLE_SUFFIX = '-stable'
+const INGRESS_ROUTE = 'INGRESS';
+const SMI_ROUTE = 'SMI';
+
+export function isBlueGreenDeploymentStrategy() {
+    const deploymentStrategy = TaskInputParameters.deploymentStrategy;
+    return deploymentStrategy && deploymentStrategy.toUpperCase() === BLUE_GREEN_DEPLOYMENT_STRATEGY;
+}
+
+export function isIngressRoute(): boolean {
+    const routeMethod = TaskInputParameters.routeMethod;
+    return routeMethod && routeMethod.toUpperCase() === INGRESS_ROUTE;
+}
+
+export function isSMIRoute(): boolean {
+    const routeMethod = TaskInputParameters.routeMethod;
+    return routeMethod && routeMethod.toUpperCase() === SMI_ROUTE;
+}
+
+export async function routeBlueGreen(kubectl: Kubectl, inputManifestFiles: string[]) {
+    // get buffer time
+    let bufferTime: number = parseInt(TaskInputParameters.versionSwitchBuffer);
+
+    //logging start of buffer time
+    let dateNow = new Date();
+    console.log('starting buffer time of '+bufferTime+' minute/s at '+dateNow.toISOString()+' UTC');
+    // waiting
+    await sleep(bufferTime*1000*60);
+    // logging end of buffer time
+    dateNow = new Date();
+    console.log('stopping buffer time of '+bufferTime+' minute/s at '+dateNow.toISOString()+' UTC');
+    
+    const manifestObjects = getManifestObjects(inputManifestFiles);
+    // routing to new deployments
+    if (isIngressRoute()) {
+        routeBlueGreenIngress(kubectl, BLUE_GREEN_NEW_LABEL_VALUE, manifestObjects.serviceNameMap, manifestObjects.serviceEntityList, manifestObjects.ingressEntityList);    
+    } else if (isSMIRoute()) {
+        routeBlueGreenSMI(kubectl,  BLUE_GREEN_NEW_LABEL_VALUE, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
+    } else {
+        routeBlueGreenService(kubectl, BLUE_GREEN_NEW_LABEL_VALUE, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
+    }
+}
+
 
 export function deleteWorkloadsWithLabel(kubectl: Kubectl, deleteLabel: string, deploymentEntityList: any[]) {
-    
     let delList = []
     deploymentEntityList.forEach((inputObject) => {
         const name = inputObject.metadata.name;
@@ -51,7 +97,9 @@ export function cleanUp(kubectl: Kubectl, deploymentEntityList: any[], serviceEn
         deploymentEntityList.forEach((depObject) => {
             const kind = depObject.kind;
             const name = depObject.metadata.name;
-            if (getServiceSelector(inputObject) && getDeploymentMatchLabels(depObject) && getServiceSelector(inputObject) === getDeploymentMatchLabels(depObject)) {
+            const serviceSelector: string = getServiceSelector(inputObject);
+            const matchLabels: string = getDeploymentMatchLabels(depObject); 
+            if (!!serviceSelector && !!matchLabels && isServiceSelectorSubsetOfMatchLabel(serviceSelector, matchLabels)) {
                 const existingDeploy = fetchResource(kubectl, kind, name);
                 // checking if it has something to target
                 if (!existingDeploy) {
@@ -73,7 +121,6 @@ export function cleanUp(kubectl: Kubectl, deploymentEntityList: any[], serviceEn
 }
 
 export function deleteWorkloadsAndServicesWithLabel(kubectl: Kubectl, deleteLabel: string, deploymentEntityList: any[], serviceEntityList: any[]) {
-
     // need to delete services and deployments
     const deletionEntitiesList = deploymentEntityList.concat(serviceEntityList);
     let deleteList = []
@@ -135,7 +182,7 @@ export function getManifestObjects (filePaths: string[]): any {
     })
 
     let serviceNameMap = new Map<string, string>();
-    // find all services and adding they names with blue green suffix 
+    // find all services and add their names with blue green suffix
     serviceEntityList.forEach(inputObject => {
         const name = inputObject.metadata.name;
         serviceNameMap.set(name, getBlueGreenResourceName(name, BLUE_GREEN_SUFFIX));
@@ -144,12 +191,11 @@ export function getManifestObjects (filePaths: string[]): any {
     return { serviceEntityList: serviceEntityList, serviceNameMap: serviceNameMap, deploymentEntityList: deploymentEntityList, ingressEntityList: ingressEntityList, otherObjects: otherEntitiesList };
 }
 
-export function createWorkloadssWithLabel(kubectl: Kubectl, depObjectList: any[], nextLabel: string) {
+export function createWorkloadsWithLabel(kubectl: Kubectl, depObjectList: any[], nextLabel: string) {
     const newObjectsList = [];
     depObjectList.forEach((inputObject) => {
-        const blueGreenReplicaCount = helper.getReplicaCount(inputObject);
         // creating deployment with label
-        const newBlueGreenObject = getNewBlueGreenObject(inputObject, blueGreenReplicaCount, nextLabel);
+        const newBlueGreenObject = getNewBlueGreenObject(inputObject, nextLabel);
         core.debug('New blue-green object is: ' + JSON.stringify(newBlueGreenObject));
         newObjectsList.push(newBlueGreenObject);
     });
@@ -159,7 +205,7 @@ export function createWorkloadssWithLabel(kubectl: Kubectl, depObjectList: any[]
     return { 'result': result, 'newFilePaths': manifestFiles };
 }
 
-export function getNewBlueGreenObject(inputObject: any, replicas: number, labelValue: string): object {
+export function getNewBlueGreenObject(inputObject: any, labelValue: string): object {
     const newObject = JSON.parse(JSON.stringify(inputObject));
 
     // Updating name only if label is green label is given
@@ -170,10 +216,6 @@ export function getNewBlueGreenObject(inputObject: any, replicas: number, labelV
     // Adding labels and annotations
     addBlueGreenLabelsAndAnnotations(newObject, labelValue);
 
-    // Updating no. of replicas
-    if (isSpecContainsReplicas(newObject.kind)) {
-        newObject.spec.replicas = replicas;
-    }
     return newObject;
 }
 
@@ -192,14 +234,8 @@ export function addBlueGreenLabelsAndAnnotations(inputObject: any, labelValue: s
     }
 }
 
-function isSpecContainsReplicas(kind: string) {
-    return !isEqual(kind, KubernetesWorkload.pod, StringComparer.OrdinalIgnoreCase) &&
-        !isEqual(kind, KubernetesWorkload.daemonSet, StringComparer.OrdinalIgnoreCase) &&
-        !helper.isServiceEntity(kind)
-}
-
 export function getBlueGreenResourceName(name: string, suffix: string) {
-    return name + suffix;
+    return `${name}${suffix}`;
 }
 
 
@@ -210,20 +246,41 @@ export function getSpecLabel(inputObject: any): string {
     return '';
 }
 
-export function getDeploymentMatchLabels(inputObject) {
-    if (inputObject.kind.toUpperCase()=='POD' && !!inputObject && !!inputObject.metadata && !!inputObject.metadata.labels) {
+export function getDeploymentMatchLabels(inputObject): string {
+    if (inputObject.kind.toUpperCase()==KubernetesWorkload.pod && !!inputObject && !!inputObject.metadata && !!inputObject.metadata.labels) {
         return JSON.stringify(inputObject.metadata.labels);
     } else if (!!inputObject && inputObject.spec && inputObject.spec.selector && inputObject.spec.selector.matchLabels) {
         return JSON.stringify(inputObject.spec.selector.matchLabels);
     }
-    return false;
+    return '';
 }
 
-export function getServiceSelector(inputObject: any) {
+export function getServiceSelector(inputObject: any): string {
     if (!!inputObject && inputObject.spec && inputObject.spec.selector) {
         return JSON.stringify(inputObject.spec.selector);
-    } else return false;
+    } else return '';
 }
+
+export function isServiceSelectorSubsetOfMatchLabel(serviceSelector: string, matchLabels: string): boolean {
+    let serviceSelectorMap = new Map();
+    let matchLabelsMap = new Map();
+  
+    JSON.parse(serviceSelector, (key, value) => {
+      serviceSelectorMap.set(key, value);
+    });
+    JSON.parse(matchLabels, (key, value) => {
+      matchLabelsMap.set(key, value);
+    });
+  
+    let isMatch = true;
+    serviceSelectorMap.forEach((value, key) => {
+      if (!!key && (!matchLabelsMap.has(key) || matchLabelsMap.get(key)) != value) {
+        isMatch = false;
+      }
+    });
+  
+    return isMatch;
+  }
 
 export function fetchResource(kubectl: Kubectl, kind: string, name: string) {
     const result = kubectl.getResource(kind, name);

--- a/src/utilities/strategy-helpers/blue-green-helper.ts
+++ b/src/utilities/strategy-helpers/blue-green-helper.ts
@@ -110,7 +110,7 @@ export function deleteWorkloadsAndServicesWithLabel(kubectl: Kubectl, deleteLabe
     deletionEntitiesList.forEach((inputObject) => {
         const name = inputObject.metadata.name;
         const kind = inputObject.kind;
-        if (!deleteLabel) {
+        if (deleteLabel === NONE_LABEL_VALUE) {
             // if not dellabel, delete stable objects
             const resourceToDelete = { name : name, kind : kind};
             resourcesToDelete.push(resourceToDelete);

--- a/src/utilities/strategy-helpers/blue-green-helper.ts
+++ b/src/utilities/strategy-helpers/blue-green-helper.ts
@@ -248,7 +248,7 @@ export function getSpecLabel(inputObject: any): string {
 }
 
 export function getDeploymentMatchLabels(deploymentObject: any): string {
-    if (!!deploymentObject && deploymentObject.kind.toUpperCase()==KubernetesWorkload.pod && !!deploymentObject && !!deploymentObject.metadata && !!deploymentObject.metadata.labels) {
+    if (!!deploymentObject && deploymentObject.kind.toUpperCase()==KubernetesWorkload.pod.toUpperCase() &&  !!deploymentObject.metadata && !!deploymentObject.metadata.labels) {
         return JSON.stringify(deploymentObject.metadata.labels);
     } else if (!!deploymentObject && deploymentObject.spec && deploymentObject.spec.selector && deploymentObject.spec.selector.matchLabels) {
         return JSON.stringify(deploymentObject.spec.selector.matchLabels);

--- a/src/utilities/strategy-helpers/blue-green-helper.ts
+++ b/src/utilities/strategy-helpers/blue-green-helper.ts
@@ -1,0 +1,271 @@
+'use strict';
+
+import * as core from '@actions/core';
+import * as fs from 'fs';
+import * as yaml from 'js-yaml';
+import { checkForErrors } from '../utility';
+import { Kubectl } from '../../kubectl-object-model';
+import { KubernetesWorkload } from '../../constants';
+import { StringComparer, isEqual } from '../string-comparison';
+import * as fileHelper from '../files-helper';
+import * as helper from '../resource-object-utility';
+
+export const BLUE_GREEN_NEW_LABEL_VALUE = 'green';
+export const NONE_LABEL_VALUE = 'None';
+export const BLUE_GREEN_VERSION_LABEL = 'k8s.deploy.color';
+export const BLUE_GREEN_SUFFIX = '-green';
+export const STABLE_SUFFIX = '-stable'
+
+export function deleteWorkloadsWithLabel(kubectl: Kubectl, deleteLabel: string, deploymentEntityList: any[]) {
+    
+    let delList = []
+    deploymentEntityList.forEach((inputObject) => {
+        const name = inputObject.metadata.name;
+        const kind = inputObject.kind;
+        if (deleteLabel === NONE_LABEL_VALUE) {
+            // if dellabel is none, deletes stable deployments
+            const tempObject = { name : name, kind : kind};
+            delList.push(tempObject);
+        } else {
+            // if dellabel is not none, then deletes new green deployments
+            const tempObject = { name : name+BLUE_GREEN_SUFFIX, kind : kind };
+            delList.push(tempObject);
+        }
+    });
+
+    // deletes the deployments
+    delList.forEach((delObject) => {
+        try {
+            const result = kubectl.delete([delObject.kind, delObject.name]);
+            checkForErrors([result]);
+        } catch (ex) {
+            // Ignore failures of delete if doesn't exist
+        }
+    });
+}
+
+export function cleanUp(kubectl: Kubectl, deploymentEntityList: any[], serviceEntityList: any[]) {
+    // checks if services has some stable deployments to target or deletes them too
+    let delList = []; 
+    serviceEntityList.forEach((inputObject) => {
+        deploymentEntityList.forEach((depObject) => {
+            const kind = depObject.kind;
+            const name = depObject.metadata.name;
+            if (getServiceSelector(inputObject) && getDeploymentMatchLabels(depObject) && getServiceSelector(inputObject) === getDeploymentMatchLabels(depObject)) {
+                const existingDeploy = fetchResource(kubectl, kind, name);
+                // checking if it has something to target
+                if (!existingDeploy) {
+                    const tempObject = { name : inputObject.metadata.name, kind : inputObject.kind };
+                    delList.push(tempObject);
+                } 
+            }
+        });
+    });
+
+    delList.forEach((delObject) => {
+        try {
+            const result = kubectl.delete([delObject.kind, delObject.name]);
+            checkForErrors([result]);
+        } catch (ex) {
+            // Ignore failures of delete if doesn't exist
+        }
+    });
+}
+
+export function deleteWorkloadsAndServicesWithLabel(kubectl: Kubectl, deleteLabel: string, deploymentEntityList: any[], serviceEntityList: any[]) {
+
+    // need to delete services and deployments
+    const deletionEntitiesList = deploymentEntityList.concat(serviceEntityList);
+    let deleteList = []
+    deletionEntitiesList.forEach((inputObject) => {
+        const name = inputObject.metadata.name;
+        const kind = inputObject.kind;
+        if (!deleteLabel) {
+            // if not dellabel, delete stable objects
+            const tempObject = { name : name, kind : kind};
+            deleteList.push(tempObject);
+        } else {
+            // else delete green labels
+            const tempObject = { name : name+BLUE_GREEN_SUFFIX, kind : kind };
+            deleteList.push(tempObject);
+        }
+    });
+
+    // delete services and deployments
+    deleteList.forEach((delObject) => {
+        try {
+            const result = kubectl.delete([delObject.kind, delObject.name]);
+            checkForErrors([result]);
+        } catch (ex) {
+            // Ignore failures of delete if doesn't exist
+        }
+    });
+}
+
+export function getSuffix(label: string): string {
+    if(label === BLUE_GREEN_NEW_LABEL_VALUE) {
+        return BLUE_GREEN_SUFFIX
+    } else {
+        return '';
+    }
+}
+
+// other common functions
+export function getManifestObjects (filePaths: string[]): any {
+    const deploymentEntityList = [];
+    const serviceEntityList = [];
+    const ingressEntityList = [];
+    const otherEntitiesList = [];
+    filePaths.forEach((filePath: string) => {
+        const fileContents = fs.readFileSync(filePath);
+        yaml.safeLoadAll(fileContents, function (inputObject) {
+            if(!!inputObject) {
+                const kind = inputObject.kind;
+                if (helper.isDeploymentEntity(kind)) {
+                    deploymentEntityList.push(inputObject);
+                } else if (helper.isServiceEntity(kind)) {
+                    serviceEntityList.push(inputObject);
+                } else if (helper.isIngressEntity(kind)) {
+                    ingressEntityList.push(inputObject);
+                } else {
+                    otherEntitiesList.push(inputObject);
+                }
+            }
+        });
+    })
+
+    let serviceNameMap = new Map<string, string>();
+    // find all services and adding they names with blue green suffix 
+    serviceEntityList.forEach(inputObject => {
+        const name = inputObject.metadata.name;
+        serviceNameMap.set(name, getBlueGreenResourceName(name, BLUE_GREEN_SUFFIX));
+    });
+     
+    return { serviceEntityList: serviceEntityList, serviceNameMap: serviceNameMap, deploymentEntityList: deploymentEntityList, ingressEntityList: ingressEntityList, otherObjects: otherEntitiesList };
+}
+
+export function createWorkloadssWithLabel(kubectl: Kubectl, depObjectList: any[], nextLabel: string) {
+    const newObjectsList = [];
+    depObjectList.forEach((inputObject) => {
+        const blueGreenReplicaCount = helper.getReplicaCount(inputObject);
+        // creating deployment with label
+        const newBlueGreenObject = getNewBlueGreenObject(inputObject, blueGreenReplicaCount, nextLabel);
+        core.debug('New blue-green object is: ' + JSON.stringify(newBlueGreenObject));
+        newObjectsList.push(newBlueGreenObject);
+    });
+    const manifestFiles = fileHelper.writeObjectsToFile(newObjectsList);
+    const result = kubectl.apply(manifestFiles);
+
+    return { 'result': result, 'newFilePaths': manifestFiles };
+}
+
+export function getNewBlueGreenObject(inputObject: any, replicas: number, labelValue: string): object {
+    const newObject = JSON.parse(JSON.stringify(inputObject));
+
+    // Updating name only if label is green label is given
+    if (labelValue === BLUE_GREEN_NEW_LABEL_VALUE) {
+        newObject.metadata.name = getBlueGreenResourceName(inputObject.metadata.name, BLUE_GREEN_SUFFIX);
+    }
+
+    // Adding labels and annotations
+    addBlueGreenLabelsAndAnnotations(newObject, labelValue);
+
+    // Updating no. of replicas
+    if (isSpecContainsReplicas(newObject.kind)) {
+        newObject.spec.replicas = replicas;
+    }
+    return newObject;
+}
+
+export function addBlueGreenLabelsAndAnnotations(inputObject: any, labelValue: string) {
+    //creating the k8s.deploy.color label
+    const newLabels = new Map<string, string>();
+    newLabels[BLUE_GREEN_VERSION_LABEL] = labelValue;
+
+    // updating object labels and selector labels
+    helper.updateObjectLabels(inputObject, newLabels, false);
+    helper.updateSelectorLabels(inputObject, newLabels, false);
+
+    // updating spec labels if it is a service
+    if (!helper.isServiceEntity(inputObject.kind)) {
+        helper.updateSpecLabels(inputObject, newLabels, false);
+    }
+}
+
+function isSpecContainsReplicas(kind: string) {
+    return !isEqual(kind, KubernetesWorkload.pod, StringComparer.OrdinalIgnoreCase) &&
+        !isEqual(kind, KubernetesWorkload.daemonSet, StringComparer.OrdinalIgnoreCase) &&
+        !helper.isServiceEntity(kind)
+}
+
+export function getBlueGreenResourceName(name: string, suffix: string) {
+    return name + suffix;
+}
+
+
+export function getSpecLabel(inputObject: any): string {
+    if(!!inputObject && inputObject.spec && inputObject.spec.selector && inputObject.spec.selector.matchLabels && inputObject.spec.selector.matchLabels[BLUE_GREEN_VERSION_LABEL]) {
+        return inputObject.spec.selector.matchLabels[BLUE_GREEN_VERSION_LABEL]; 
+    }
+    return '';
+}
+
+export function getDeploymentMatchLabels(inputObject) {
+    if (inputObject.kind.toUpperCase()=='POD' && !!inputObject && !!inputObject.metadata && !!inputObject.metadata.labels) {
+        return JSON.stringify(inputObject.metadata.labels);
+    } else if (!!inputObject && inputObject.spec && inputObject.spec.selector && inputObject.spec.selector.matchLabels) {
+        return JSON.stringify(inputObject.spec.selector.matchLabels);
+    }
+    return false;
+}
+
+export function getServiceSelector(inputObject: any) {
+    if (!!inputObject && inputObject.spec && inputObject.spec.selector) {
+        return JSON.stringify(inputObject.spec.selector);
+    } else return false;
+}
+
+export function fetchResource(kubectl: Kubectl, kind: string, name: string) {
+    const result = kubectl.getResource(kind, name);
+    if (result == null || !!result.stderr) {
+        return null;
+    }
+
+    if (!!result.stdout) {
+        const resource = JSON.parse(result.stdout);
+        try {
+            UnsetsClusterSpecficDetails(resource);
+            return resource;
+        } catch (ex) {
+            core.debug('Exception occurred while Parsing ' + resource + ' in Json object');
+            core.debug(`Exception:${ex}`);
+        }
+    }
+    return null;
+}
+
+function UnsetsClusterSpecficDetails(resource: any) {
+    if (resource == null) {
+        return;
+    }
+
+    // Unsets the cluster specific details in the object
+    if (!!resource) {
+        const metadata = resource.metadata;
+        const status = resource.status;
+
+        if (!!metadata) {
+            const newMetadata = {
+                'annotations': metadata.annotations,
+                'labels': metadata.labels,
+                'name': metadata.name
+            };
+
+            resource.metadata = newMetadata;
+        }
+
+        if (!!status) {
+            resource.status = {};
+        }
+    }
+}

--- a/src/utilities/strategy-helpers/deployment-helper.ts
+++ b/src/utilities/strategy-helpers/deployment-helper.ts
@@ -1,8 +1,6 @@
 'use strict';
 
 import * as fs from 'fs';
-import * as path from 'path';
-import * as core from '@actions/core';
 import * as yaml from 'js-yaml';
 import * as canaryDeploymentHelper from './canary-deployment-helper';
 import * as KubernetesObjectUtility from '../resource-object-utility';
@@ -13,29 +11,32 @@ import * as utils from '../manifest-utilities';
 import * as KubernetesManifestUtility from '../manifest-stability-utility';
 import * as KubernetesConstants from '../../constants';
 import { Kubectl, Resource } from '../../kubectl-object-model';
-
+import { getUpdatedManifestFiles } from '../manifest-utilities';
 import { deployPodCanary } from './pod-canary-deployment-helper';
 import { deploySMICanary } from './smi-canary-deployment-helper';
-import { checkForErrors } from "../utility";
+import { checkForErrors, sleep } from "../utility";
+import { BLUE_GREEN_NEW_LABEL_VALUE, getManifestObjects } from './blue-green-helper';
+import { deployBlueGreen, blueGreenRouteService, isBlueGreenDeploymentStrategy } from './service-blue-green-helper';
+import { deployBlueGreenIngress, blueGreenRouteIngress, isIngressRoute } from './ingress-blue-green-helper';
+import { deployBlueGreenSMI, blueGreenRouteTraffic, isSMIRoute } from './smi-blue-green-helper';
 
 
 export async function deploy(kubectl: Kubectl, manifestFilePaths: string[], deploymentStrategy: string) {
 
     // get manifest files
-    let inputManifestFiles: string[] = getManifestFiles(manifestFilePaths);
-
-    // artifact substitution
-    inputManifestFiles = updateContainerImagesInManifestFiles(inputManifestFiles, TaskInputParameters.containers);
-
-    // imagePullSecrets addition
-    inputManifestFiles = updateImagePullSecretsInManifestFiles(inputManifestFiles, TaskInputParameters.imagePullSecrets);
+    let inputManifestFiles: string[] = getUpdatedManifestFiles(manifestFilePaths);
 
     // deployment
-    const deployedManifestFiles = deployManifests(inputManifestFiles, kubectl, isCanaryDeploymentStrategy(deploymentStrategy));
+    const deployedManifestFiles = deployManifests(inputManifestFiles, kubectl, isCanaryDeploymentStrategy(deploymentStrategy), isBlueGreenDeploymentStrategy());
 
     // check manifest stability
     const resourceTypes: Resource[] = KubernetesObjectUtility.getResources(deployedManifestFiles, models.deploymentTypes.concat([KubernetesConstants.DiscoveryAndLoadBalancerResource.service]));
     await checkManifestStability(kubectl, resourceTypes);
+
+    // route blue-green deployments
+    if (isBlueGreenDeploymentStrategy()) {
+        await routeBlueGreen(kubectl, inputManifestFiles);
+    }
 
     // print ingress resources
     const ingressResources: Resource[] = KubernetesObjectUtility.getResources(deployedManifestFiles, [KubernetesConstants.DiscoveryAndLoadBalancerResource.ingress]);
@@ -44,7 +45,31 @@ export async function deploy(kubectl: Kubectl, manifestFilePaths: string[], depl
     });
 }
 
-function getManifestFiles(manifestFilePaths: string[]): string[] {
+async function routeBlueGreen(kubectl: Kubectl, inputManifestFiles: string[]) {
+    // get buffer time
+    let sleepTime: number = parseInt(TaskInputParameters.versionSwitchBuffer);
+
+    //logging start of buffer time
+    let temp = new Date();
+    console.log('starting buffer time of '+sleepTime+' minute/s at '+temp.getHours()+':'+temp.getMinutes()+':'+temp.getSeconds()+' UTC');
+    // waiting
+    await sleep(sleepTime*1000*60);
+    // logging end of buffer time
+    temp = new Date();
+    console.log('stopping buffer time of '+sleepTime+' minute/s at '+temp.getHours()+':'+temp.getMinutes()+':'+temp.getSeconds()+' UTC');
+    
+    const manifestObjects = getManifestObjects(inputManifestFiles);
+    // routing to new deployments
+    if (isIngressRoute()) {
+        blueGreenRouteIngress(kubectl, BLUE_GREEN_NEW_LABEL_VALUE, manifestObjects.serviceNameMap, manifestObjects.serviceEntityList, manifestObjects.ingressEntityList);    
+    } else if (isSMIRoute()) {
+        blueGreenRouteTraffic(kubectl,  BLUE_GREEN_NEW_LABEL_VALUE, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
+    } else {
+        blueGreenRouteService(kubectl, BLUE_GREEN_NEW_LABEL_VALUE, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
+    }
+}
+
+export function getManifestFiles(manifestFilePaths: string[]): string[] {
     const files: string[] = utils.getManifestFiles(manifestFilePaths);
 
     if (files == null || files.length === 0) {
@@ -54,7 +79,7 @@ function getManifestFiles(manifestFilePaths: string[]): string[] {
     return files;
 }
 
-function deployManifests(files: string[], kubectl: Kubectl, isCanaryDeploymentStrategy: boolean): string[] {
+function deployManifests(files: string[], kubectl: Kubectl, isCanaryDeploymentStrategy: boolean, isBlueGreenDeploymentStrategy: boolean): string[] {
     let result;
     if (isCanaryDeploymentStrategy) {
         let canaryDeploymentOutput: any;
@@ -65,6 +90,17 @@ function deployManifests(files: string[], kubectl: Kubectl, isCanaryDeploymentSt
         }
         result = canaryDeploymentOutput.result;
         files = canaryDeploymentOutput.newFilePaths;
+    } else if (isBlueGreenDeploymentStrategy) {
+        let blueGreenDeploymentOutput: any; 
+        if (isIngressRoute()) {
+            blueGreenDeploymentOutput = deployBlueGreenIngress(kubectl, files);
+        } else if (isSMIRoute()) {
+            blueGreenDeploymentOutput = deployBlueGreenSMI(kubectl, files);
+        } else {
+            blueGreenDeploymentOutput = deployBlueGreen(kubectl, files);
+        }
+        result = blueGreenDeploymentOutput.result;
+        files = blueGreenDeploymentOutput.newFilePaths;
     } else {
         if (canaryDeploymentHelper.isSMICanaryStrategy()) {
             const updatedManifests = appendStableVersionLabelToResource(files, kubectl);
@@ -102,58 +138,6 @@ function appendStableVersionLabelToResource(files: string[], kubectl: Kubectl): 
 
 async function checkManifestStability(kubectl: Kubectl, resources: Resource[]): Promise<void> {
     await KubernetesManifestUtility.checkManifestStability(kubectl, resources);
-}
-
-function updateContainerImagesInManifestFiles(filePaths: string[], containers: string[]): string[] {
-    if (!!containers && containers.length > 0) {
-        const newFilePaths = [];
-        const tempDirectory = fileHelper.getTempDirectory();
-        filePaths.forEach((filePath: string) => {
-            let contents = fs.readFileSync(filePath).toString();
-            containers.forEach((container: string) => {
-                let imageName = container.split(':')[0];
-                if (imageName.indexOf('@') > 0) {
-                    imageName = imageName.split('@')[0];
-                }
-                if (contents.indexOf(imageName) > 0) {
-                    contents = utils.substituteImageNameInSpecFile(contents, imageName, container);
-                }
-            });
-
-            const fileName = path.join(tempDirectory, path.basename(filePath));
-            fs.writeFileSync(
-                path.join(fileName),
-                contents
-            );
-            newFilePaths.push(fileName);
-        });
-
-        return newFilePaths;
-    }
-
-    return filePaths;
-}
-
-function updateImagePullSecretsInManifestFiles(filePaths: string[], imagePullSecrets: string[]): string[] {
-    if (!!imagePullSecrets && imagePullSecrets.length > 0) {
-        const newObjectsList = [];
-        filePaths.forEach((filePath: string) => {
-            const fileContents = fs.readFileSync(filePath).toString();
-            yaml.safeLoadAll(fileContents, function (inputObject: any) {
-                if (!!inputObject && !!inputObject.kind) {
-                    const kind = inputObject.kind;
-                    if (KubernetesObjectUtility.isWorkloadEntity(kind)) {
-                        KubernetesObjectUtility.updateImagePullSecrets(inputObject, imagePullSecrets, false);
-                    }
-                    newObjectsList.push(inputObject);
-                }
-            });
-        });
-        core.debug('New K8s objects after addin imagePullSecrets are :' + JSON.stringify(newObjectsList));
-        const newFilePaths = fileHelper.writeObjectsToFile(newObjectsList);
-        return newFilePaths;
-    }
-    return filePaths;
 }
 
 function isCanaryDeploymentStrategy(deploymentStrategy: string): boolean {

--- a/src/utilities/strategy-helpers/ingress-blue-green-helper.ts
+++ b/src/utilities/strategy-helpers/ingress-blue-green-helper.ts
@@ -1,0 +1,179 @@
+'use strict';
+
+import * as core from '@actions/core';
+import { Kubectl } from '../../kubectl-object-model';
+import * as fileHelper from '../files-helper';
+import * as TaskInputParameters from '../../input-parameters';
+import { createWorkloadssWithLabel, getManifestObjects, getNewBlueGreenObject, addBlueGreenLabelsAndAnnotations, deleteWorkloadsAndServicesWithLabel, fetchResource } from './blue-green-helper';
+import { BLUE_GREEN_NEW_LABEL_VALUE, NONE_LABEL_VALUE, BLUE_GREEN_VERSION_LABEL } from './blue-green-helper';
+
+const INGRESS_ROUTE = 'INGRESS';
+
+export function isIngressRoute(): boolean {
+    const routeMethod = TaskInputParameters.routeMethod;
+    return routeMethod && routeMethod.toUpperCase() === INGRESS_ROUTE;
+}
+export function deployBlueGreenIngress(kubectl: Kubectl, filePaths: string[]) {
+
+    // get all kubernetes objects defined in manifest files
+    const manifestObjects = getManifestObjects(filePaths);
+
+    // create deployments with green label value
+    const result = createWorkloadssWithLabel(kubectl, manifestObjects.deploymentEntityList, BLUE_GREEN_NEW_LABEL_VALUE);
+
+    // create new services and other objects 
+    let newObjectsList = [];
+    manifestObjects.serviceEntityList.forEach(inputObject => {
+        const newBlueGreenObject = getNewBlueGreenObject(inputObject, 0, BLUE_GREEN_NEW_LABEL_VALUE);;
+        core.debug('New blue-green object is: ' + JSON.stringify(newBlueGreenObject));
+        newObjectsList.push(newBlueGreenObject);
+    });
+    newObjectsList = newObjectsList.concat(manifestObjects.otherObjects);
+
+    const manifestFiles = fileHelper.writeObjectsToFile(newObjectsList);
+    kubectl.apply(manifestFiles);
+    
+    // return results to check for manifest stability
+    return result;
+}
+
+export async function blueGreenPromoteIngress(kubectl: Kubectl, manifestObjects) {
+
+    //checking if anything to promote
+    if (!validateIngressState(kubectl, manifestObjects.ingressEntityList, manifestObjects.serviceNameMap)) {
+        throw('NotInPromoteStateIngress');
+    }
+
+    // deleting existing stable deploymetns and services
+    deleteWorkloadsAndServicesWithLabel(kubectl, null, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
+
+    // create stable deployments with new configuration
+    const result = createWorkloadssWithLabel(kubectl, manifestObjects.deploymentEntityList, NONE_LABEL_VALUE);
+
+    // create stable services
+    const newObjectsList = [];
+    manifestObjects.serviceEntityList.forEach((inputObject) => {
+        const newBlueGreenObject = getNewBlueGreenObject(inputObject, 0, NONE_LABEL_VALUE);
+        core.debug('New blue-green object is: ' + JSON.stringify(newBlueGreenObject));
+        newObjectsList.push(newBlueGreenObject);
+    });
+    
+    const manifestFiles = fileHelper.writeObjectsToFile(newObjectsList);
+    kubectl.apply(manifestFiles);
+    
+    // returning deployments to check for rollout stability
+    return result;
+}
+
+export async function blueGreenRejectIngress(kubectl: Kubectl, filePaths: string[]) {
+
+    // get all kubernetes objects defined in manifest files
+    const manifestObjects = getManifestObjects(filePaths);
+    
+    // routing ingress to stables services
+    blueGreenRouteIngress(kubectl, null, manifestObjects.serviceNameMap, manifestObjects.serviceEntityList, manifestObjects.ingressEntityList);
+    
+    // deleting green services and deployments
+    deleteWorkloadsAndServicesWithLabel(kubectl, BLUE_GREEN_NEW_LABEL_VALUE, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
+}
+
+export function blueGreenRouteIngress(kubectl: Kubectl, nextLabel: string, serviceNameMap: Map<string, string>, serviceEntityList: any[],  ingressEntityList: any[]) {
+    
+    let newObjectsList = [];
+    if (!nextLabel) {
+        newObjectsList = newObjectsList.concat(ingressEntityList);
+    } else {
+        ingressEntityList.forEach((inputObject) => {
+            let isRouted: boolean = false;
+
+            // sees if ingress targets a service in the given manifests
+            JSON.parse(JSON.stringify(inputObject), (key, value) => {
+                if (key === 'serviceName' && serviceNameMap.has(value)) {
+                    isRouted = true;
+                }
+                return value;
+            });
+
+            // routing to green objects only if ingress is routed
+            if (isRouted) {
+                const newBlueGreenIngressObject = getUpdatedBlueGreenIngress(inputObject, serviceNameMap, BLUE_GREEN_NEW_LABEL_VALUE);
+                newObjectsList.push(newBlueGreenIngressObject);
+            } else {
+                newObjectsList.push(inputObject);
+            }
+        });
+    }
+
+    const manifestFiles = fileHelper.writeObjectsToFile(newObjectsList);
+    kubectl.apply(manifestFiles);
+}
+
+export function validateIngressState(kubectl: Kubectl, ingressEntityList: any[], serviceNameMap: Map<string, string>): boolean {
+
+    let isIngressTargetingNewServices: boolean = true;
+    ingressEntityList.forEach((inputObject) => {
+        let isRouted: boolean = false;
+        // finding if ingress is targeting a service in given manifests
+        JSON.parse(JSON.stringify(inputObject), (key, value) => {
+            if (key === 'serviceName' && serviceNameMap.has(value)) {
+                isRouted = true;
+            }
+            return value;
+        });
+
+        if (isRouted) {
+            //querying existing ingress
+            let existingIngress = fetchResource(kubectl, inputObject.kind, inputObject.metadata.name);
+            if(!!existingIngress) {
+                let currentLabel: string;
+                // checking its label
+                try {
+                    currentLabel = existingIngress.metadata.labels[BLUE_GREEN_VERSION_LABEL];
+                } catch {
+                    // if no label exists, then not an ingress targeting green deployments
+                    isIngressTargetingNewServices = false;
+                }
+                if (currentLabel != BLUE_GREEN_NEW_LABEL_VALUE) {
+                    // if not green label, then wrong configuration
+                    isIngressTargetingNewServices = false;
+                }
+            } else {
+                // no ingress at all, so nothing to promote
+                isIngressTargetingNewServices = false;
+            }
+        }
+    });
+
+    return isIngressTargetingNewServices;
+}
+
+
+export function getUpdatedBlueGreenIngress(inputObject: any, serviceNameMap: Map<string, string>, type: string): object {
+    if(!type) {
+        // returning original with no modifications
+        return inputObject;
+    }
+    
+    const newObject = JSON.parse(JSON.stringify(inputObject));
+    //adding green labels and values
+    addBlueGreenLabelsAndAnnotations(newObject, type);
+
+    // Updating ingress labels
+    let finalObject =  updateIngressBackend(newObject, serviceNameMap);
+    return finalObject;
+}
+
+export function updateIngressBackend(inputObject: any, serviceNameMap: Map<string, string>): any {
+    inputObject = JSON.parse(JSON.stringify(inputObject), (key, value) => {
+        if(key.toUpperCase() === 'BACKEND') {
+            let serName = value.serviceName; 
+            if (serviceNameMap.has(serName)) {
+                //updating srvice name with corresponging bluegreen name only if service is provied in given manifests
+                value.serviceName = serviceNameMap.get(serName);
+            }
+        }
+        return value;
+    });
+
+    return inputObject;
+} 

--- a/src/utilities/strategy-helpers/ingress-blue-green-helper.ts
+++ b/src/utilities/strategy-helpers/ingress-blue-green-helper.ts
@@ -54,7 +54,7 @@ export async function promoteBlueGreenIngress(kubectl: Kubectl, manifestObjects)
     return result;
 }
 
-export async function blueGreenRejectIngress(kubectl: Kubectl, filePaths: string[]) {
+export async function rejectBlueGreenIngress(kubectl: Kubectl, filePaths: string[]) {
     // get all kubernetes objects defined in manifest files
     const manifestObjects = getManifestObjects(filePaths);
     

--- a/src/utilities/strategy-helpers/service-blue-green-helper.ts
+++ b/src/utilities/strategy-helpers/service-blue-green-helper.ts
@@ -2,15 +2,15 @@
 
 import { Kubectl } from '../../kubectl-object-model';
 import * as fileHelper from '../files-helper';
-import { createWorkloadsWithLabel, getManifestObjects, addBlueGreenLabelsAndAnnotations, getServiceSelector, getDeploymentMatchLabels, fetchResource, deleteWorkloadsWithLabel, cleanUp, isServiceSelectorSubsetOfMatchLabel } from './blue-green-helper';
-import { BLUE_GREEN_NEW_LABEL_VALUE, NONE_LABEL_VALUE, BLUE_GREEN_VERSION_LABEL } from './blue-green-helper';
+import { createWorkloadsWithLabel, getManifestObjects, addBlueGreenLabelsAndAnnotations, fetchResource, deleteWorkloadsWithLabel, cleanUp, isServiceRouted } from './blue-green-helper';
+import { GREEN_LABEL_VALUE, NONE_LABEL_VALUE, BLUE_GREEN_VERSION_LABEL } from './blue-green-helper';
 
 export function deployBlueGreenService(kubectl: Kubectl, filePaths: string[]) {
     // get all kubernetes objects defined in manifest files
     const manifestObjects = getManifestObjects(filePaths);
 
     // create deployments with green label value
-    const result = createWorkloadsWithLabel(kubectl, manifestObjects.deploymentEntityList, BLUE_GREEN_NEW_LABEL_VALUE);
+    const result = createWorkloadsWithLabel(kubectl, manifestObjects.deploymentEntityList, GREEN_LABEL_VALUE);
 
     // create other non deployment and non service entities
     const newObjectsList = manifestObjects.otherObjects.concat(manifestObjects.ingressEntityList);
@@ -21,14 +21,11 @@ export function deployBlueGreenService(kubectl: Kubectl, filePaths: string[]) {
     return result;
 }
 
-export async function blueGreenPromote(kubectl: Kubectl, manifestObjects) {
+export async function promoteBlueGreenService(kubectl: Kubectl, manifestObjects) {
     // checking if services are in the right state ie. targeting green deployments
-    if (!validateServiceState(kubectl, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList)) {
+    if (!validateServicesState(kubectl, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList)) {
         throw('NotInPromoteState');
     }
-
-    // deleting previous stable deployments
-    deleteWorkloadsWithLabel(kubectl, NONE_LABEL_VALUE, manifestObjects.deploymentEntityList);
 
     // creating stable deployments with new configurations
     const result = createWorkloadsWithLabel(kubectl, manifestObjects.deploymentEntityList, NONE_LABEL_VALUE);
@@ -48,28 +45,19 @@ export async function blueGreenReject(kubectl: Kubectl, filePaths: string[]) {
     cleanUp(kubectl, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
     
     // deleting the new deployments with green suffix
-    deleteWorkloadsWithLabel(kubectl, BLUE_GREEN_NEW_LABEL_VALUE, manifestObjects.deploymentEntityList);
+    deleteWorkloadsWithLabel(kubectl, GREEN_LABEL_VALUE, manifestObjects.deploymentEntityList);
 }
 
 export function routeBlueGreenService(kubectl: Kubectl, nextLabel: string, deploymentEntityList: any[], serviceEntityList: any[]) {
     const newObjectsList = [];
-    serviceEntityList.forEach((inputObject) => {
-        let isRouted: boolean = false;
-        deploymentEntityList.forEach((depObject) => {
-            // finding if there is a deployment in the given manifests the service targets
-            const serviceSelector: string = getServiceSelector(inputObject);
-            const matchLabels: string = getDeploymentMatchLabels(depObject); 
-            if (!!serviceSelector && !!matchLabels && isServiceSelectorSubsetOfMatchLabel(serviceSelector, matchLabels)) {
-                isRouted = true;
-                // decided that this service needs to be routed
-                // point to the given nextlabel
-                const newBlueGreenServiceObject = getUpdatedBlueGreenService(inputObject, nextLabel);
-                newObjectsList.push(newBlueGreenServiceObject);
-            }
-        });
-        if (!isRouted) {
+    serviceEntityList.forEach((serviceObject) => {
+        if (isServiceRouted(serviceObject, deploymentEntityList)) {
+            // if service is routed, point it to given label
+            const newBlueGreenServiceObject = getUpdatedBlueGreenService(serviceObject, nextLabel);
+            newObjectsList.push(newBlueGreenServiceObject);
+        } else {
             // if service is not routed, just push the original service
-            newObjectsList.push(inputObject);
+            newObjectsList.push(serviceObject);
         }
     });
     // configures the services
@@ -85,32 +73,25 @@ function getUpdatedBlueGreenService(inputObject: any, labelValue: string): objec
     return newObject;
 }
 
-
-export function validateServiceState(kubectl: Kubectl, deploymentEntityList: any[], serviceEntityList: any[]): boolean {
-    let isServiceTargetingNewWorkloads: boolean = true;
-    serviceEntityList.forEach((inputObject) => {
-        deploymentEntityList.forEach((depObject) => {
-            // finding out if the service is pointing to a deployment in this manifest
-            const serviceSelector: string = getServiceSelector(inputObject);
-            const matchLabels: string = getDeploymentMatchLabels(depObject); 
-            if (!!serviceSelector && !!matchLabels && isServiceSelectorSubsetOfMatchLabel(serviceSelector, matchLabels)) {
-                // finding the existing routed service
-                let existingService = fetchResource(kubectl, inputObject.kind, inputObject.metadata.name);
-                if (!!existingService) {
-                    let currentLabel: string = getServiceSpecLabel(existingService);
-                    if(currentLabel != BLUE_GREEN_NEW_LABEL_VALUE) {
-                        // service should be targeting deployments with green label
-                        isServiceTargetingNewWorkloads = false;
-                    }
-                } else {
-                    // service targeting deployment doesn't exist
-                    isServiceTargetingNewWorkloads = false;
+export function validateServicesState(kubectl: Kubectl, deploymentEntityList: any[], serviceEntityList: any[]): boolean {
+    let areServicesGreen: boolean = true;
+    serviceEntityList.forEach((serviceObject) => {
+        if (isServiceRouted(serviceObject, deploymentEntityList)) {
+            // finding the existing routed service
+            const existingService = fetchResource(kubectl, serviceObject.kind, serviceObject.metadata.name);
+            if (!!existingService) {
+                let currentLabel: string = getServiceSpecLabel(existingService);
+                if(currentLabel != GREEN_LABEL_VALUE) {
+                    // service should be targeting deployments with green label
+                    areServicesGreen = false;
                 }
+            } else {
+                // service targeting deployment doesn't exist
+                areServicesGreen = false;
             }
-        });
+        }
     });
-
-    return isServiceTargetingNewWorkloads;
+    return areServicesGreen;
 }
 
 export function getServiceSpecLabel(inputObject: any): string {

--- a/src/utilities/strategy-helpers/service-blue-green-helper.ts
+++ b/src/utilities/strategy-helpers/service-blue-green-helper.ts
@@ -1,0 +1,130 @@
+'use strict';
+
+import { Kubectl } from '../../kubectl-object-model';
+import * as fileHelper from '../files-helper';
+import * as TaskInputParameters from '../../input-parameters';
+import { createWorkloadssWithLabel, getManifestObjects, addBlueGreenLabelsAndAnnotations, getServiceSelector, getDeploymentMatchLabels, fetchResource, deleteWorkloadsWithLabel, cleanUp } from './blue-green-helper';
+import { BLUE_GREEN_NEW_LABEL_VALUE, NONE_LABEL_VALUE, BLUE_GREEN_VERSION_LABEL } from './blue-green-helper';
+
+export const BLUE_GREEN_DEPLOYMENT_STRATEGY = 'BLUE-GREEN';
+
+export function isBlueGreenDeploymentStrategy() {
+    const deploymentStrategy = TaskInputParameters.deploymentStrategy;
+    return deploymentStrategy && deploymentStrategy.toUpperCase() === BLUE_GREEN_DEPLOYMENT_STRATEGY;
+}
+
+export function deployBlueGreen(kubectl: Kubectl, filePaths: string[]) {
+
+    // get all kubernetes objects defined in manifest files
+    const manifestObjects = getManifestObjects(filePaths);
+
+    // create deployments with green label value
+    const result = createWorkloadssWithLabel(kubectl, manifestObjects.deploymentEntityList, BLUE_GREEN_NEW_LABEL_VALUE);
+
+    // create other non deployment and non service entities
+    const newObjectsList = manifestObjects.otherObjects.concat(manifestObjects.ingressEntityList);
+    const manifestFiles = fileHelper.writeObjectsToFile(newObjectsList);
+    kubectl.apply(manifestFiles);
+    
+    // returning deployment details to check for rollout stability
+    return result;
+}
+
+export async function blueGreenPromote(kubectl: Kubectl, manifestObjects) {
+
+    // checking if services are in the right state ie. targeting green deployments
+    if (!validateServiceState(kubectl, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList)) {
+        throw('NotInPromoteState');
+    }
+
+    // deleting previous stable deployments
+    deleteWorkloadsWithLabel(kubectl, NONE_LABEL_VALUE, manifestObjects.deploymentEntityList);
+
+    // creating stable deployments with new configurations
+    const result = createWorkloadssWithLabel(kubectl, manifestObjects.deploymentEntityList, NONE_LABEL_VALUE);
+    
+    // returning deployment details to check for rollout stability
+    return result;
+}
+
+export async function blueGreenReject(kubectl: Kubectl, filePaths: string[]) {
+
+    // get all kubernetes objects defined in manifest files
+    const manifestObjects = getManifestObjects(filePaths);
+
+    // routing to stable objects
+    blueGreenRouteService(kubectl, NONE_LABEL_VALUE, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
+
+    // seeing if we should even delete the service
+    cleanUp(kubectl, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
+    
+    // deleting the new deployments with green suffix
+    deleteWorkloadsWithLabel(kubectl, BLUE_GREEN_NEW_LABEL_VALUE, manifestObjects.deploymentEntityList);
+}
+
+export function blueGreenRouteService(kubectl: Kubectl, nextLabel: string, deploymentEntityList: any[], serviceEntityList: any[]) {
+    
+    const newObjectsList = [];
+    serviceEntityList.forEach((inputObject) => {
+        let isRouted: boolean = false;
+        deploymentEntityList.forEach((depObject) => {
+            // finding if there is a deployment in the given manifests the service targets
+            if (getServiceSelector(inputObject) && getDeploymentMatchLabels(depObject) && getServiceSelector(inputObject) === getDeploymentMatchLabels(depObject)) {
+                isRouted = true;
+                // decided that this service needs to be routed
+                // point to the given nextlabel
+                const newBlueGreenServiceObject = getUpdatedBlueGreenService(inputObject, nextLabel);
+                newObjectsList.push(newBlueGreenServiceObject);
+            }
+        });
+        if (!isRouted) {
+            // if service is not routed, just push the original service
+            newObjectsList.push(inputObject);
+        }
+    });
+
+    // configures the services
+    const manifestFiles = fileHelper.writeObjectsToFile(newObjectsList);
+    kubectl.apply(manifestFiles);
+}
+
+function getUpdatedBlueGreenService(inputObject: any, labelValue: string): object {
+    const newObject = JSON.parse(JSON.stringify(inputObject));
+    // Adding labels and annotations.
+    addBlueGreenLabelsAndAnnotations(newObject, labelValue);
+    return newObject;
+}
+
+
+export function validateServiceState(kubectl: Kubectl, deploymentEntityList: any[], serviceEntityList: any[]): boolean {
+    
+    let isServiceTargetingNewWorkloads: boolean = true;
+    serviceEntityList.forEach((inputObject) => {
+        deploymentEntityList.forEach((depObject) => {
+            // finding out if the service is pointing to a deployment in this manifest
+            if (getServiceSelector(inputObject) && getDeploymentMatchLabels(depObject) && getServiceSelector(inputObject) === getDeploymentMatchLabels(depObject)) {
+                // finding the existing routed service
+                let existingService = fetchResource(kubectl, inputObject.kind, inputObject.metadata.name);
+                if (!!existingService) {
+                    let currentLabel: string = getServiceSpecLabel(existingService);
+                    if(currentLabel != BLUE_GREEN_NEW_LABEL_VALUE) {
+                        // service should be targeting deployments with green label
+                        isServiceTargetingNewWorkloads = false;
+                    }
+                } else {
+                    // service targeting deployment doesn't exist
+                    isServiceTargetingNewWorkloads = false;
+                }
+            }
+        });
+    });
+
+    return isServiceTargetingNewWorkloads;
+}
+
+export function getServiceSpecLabel(inputObject: any): string {
+    if(!!inputObject && inputObject.spec && inputObject.spec.selector && inputObject.spec.selector[BLUE_GREEN_VERSION_LABEL]) {
+        return inputObject.spec.selector[BLUE_GREEN_VERSION_LABEL]; 
+    }
+    return '';
+}

--- a/src/utilities/strategy-helpers/service-blue-green-helper.ts
+++ b/src/utilities/strategy-helpers/service-blue-green-helper.ts
@@ -34,7 +34,7 @@ export async function promoteBlueGreenService(kubectl: Kubectl, manifestObjects)
     return result;
 }
 
-export async function blueGreenReject(kubectl: Kubectl, filePaths: string[]) {
+export async function rejectBlueGreenService(kubectl: Kubectl, filePaths: string[]) {
     // get all kubernetes objects defined in manifest files
     const manifestObjects = getManifestObjects(filePaths);
 

--- a/src/utilities/strategy-helpers/smi-blue-green-helper.ts
+++ b/src/utilities/strategy-helpers/smi-blue-green-helper.ts
@@ -1,0 +1,241 @@
+'use strict';
+
+import { checkForErrors } from '../utility';
+import * as util from 'util';
+import { Kubectl } from '../../kubectl-object-model';
+import * as kubectlUtils from '../kubectl-util';
+import * as fileHelper from '../files-helper';
+import * as TaskInputParameters from '../../input-parameters';
+import { createWorkloadssWithLabel, getManifestObjects, getServiceSelector, getDeploymentMatchLabels, fetchResource, deleteWorkloadsWithLabel, cleanUp, getNewBlueGreenObject, getBlueGreenResourceName } from './blue-green-helper';
+import { BLUE_GREEN_NEW_LABEL_VALUE, NONE_LABEL_VALUE, BLUE_GREEN_SUFFIX, STABLE_SUFFIX } from './blue-green-helper';
+
+let trafficSplitAPIVersion = "";
+const SMI_ROUTE = 'SMI';
+const TRAFFIC_SPLIT_OBJECT_NAME_SUFFIX = '-rollout';
+const TRAFFIC_SPLIT_OBJECT = 'TrafficSplit';
+const MIN_VAL = '0';
+const MAX_VAL = '100';
+
+export function isSMIRoute(): boolean {
+    const routeMethod = TaskInputParameters.routeMethod;
+    return routeMethod && routeMethod.toUpperCase() === SMI_ROUTE;
+}
+
+export function deployBlueGreenSMI(kubectl: Kubectl, filePaths: string[]) {
+
+    // get all kubernetes objects defined in manifest files
+    const manifestObjects = getManifestObjects(filePaths);
+
+    // creating services and other objects
+    const newObjectsList = manifestObjects.otherObjects.concat(manifestObjects.serviceEntityList).concat(manifestObjects.ingressEntityList);
+    const manifestFiles = fileHelper.writeObjectsToFile(newObjectsList);
+    kubectl.apply(manifestFiles);
+
+    // make extraservices and trafficsplit
+    setUpSMI(kubectl, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
+
+    // create new deloyments
+    const result = createWorkloadssWithLabel(kubectl, manifestObjects.deploymentEntityList, BLUE_GREEN_NEW_LABEL_VALUE);
+
+    // return results to check for manifest stability
+    return result;
+}
+
+export async function blueGreenPromoteSMI(kubectl: Kubectl, manifestObjects) {
+
+    // checking if there is something to promote
+    if (!validateTrafficSplitState(kubectl, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList)) {
+        throw('NotInPromoteStateSMI')
+    } 
+
+    //deleting old stable deployments
+    deleteWorkloadsWithLabel(kubectl, NONE_LABEL_VALUE, manifestObjects.deploymentEntityList);
+
+    // create stable deployments with new configuration
+    const result = createWorkloadssWithLabel(kubectl, manifestObjects.deploymentEntityList, NONE_LABEL_VALUE);
+
+    // return result to check for stability
+    return result;
+}
+
+export async function blueGreenRejectSMI(kubectl: Kubectl, filePaths: string[]) {
+
+    // get all kubernetes objects defined in manifest files
+    const manifestObjects = getManifestObjects(filePaths);
+
+    // routing trafficsplit to stable deploymetns
+    blueGreenRouteTraffic(kubectl, NONE_LABEL_VALUE, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
+
+    // deciding whether to delete services or not
+    cleanUp(kubectl, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
+
+    // deleting rejected new bluegreen deplyments 
+    deleteWorkloadsWithLabel(kubectl, BLUE_GREEN_NEW_LABEL_VALUE, manifestObjects.deploymentEntityList);
+
+    //deleting trafficsplit and extra services
+    cleanSetUpSMI(kubectl, manifestObjects.deploymentEntityList, manifestObjects.serviceEntityList);
+}
+
+export function setUpSMI(kubectl: Kubectl, deploymentEntityList: any[], serviceEntityList: any[]) {
+
+    const newObjectsList = [];
+    const trafficObjectList = []
+    serviceEntityList.forEach((inputObject) => {
+        deploymentEntityList.forEach((depObject) => {
+            // finding out whether service targets a deployment in given manifests
+            if (getServiceSelector(inputObject) && getDeploymentMatchLabels(depObject) && getServiceSelector(inputObject) === getDeploymentMatchLabels(depObject)) {
+                // decided that this service needs to be routed
+                //querying for both services
+                trafficObjectList.push(inputObject);
+                // setting up the services for trafficsplit
+                const newStableService = getSMIServiceResource(inputObject, STABLE_SUFFIX, 0);
+                const newGreenService = getSMIServiceResource(inputObject, BLUE_GREEN_SUFFIX, 0);
+                newObjectsList.push(newStableService);
+                newObjectsList.push(newGreenService);
+            }
+        });
+    });
+
+    // creating services
+    const manifestFiles = fileHelper.writeObjectsToFile(newObjectsList);
+    kubectl.apply(manifestFiles);
+
+    // route to stable service
+    trafficObjectList.forEach((inputObject) => {
+        createTrafficSplitObject(kubectl, inputObject.metadata.name, NONE_LABEL_VALUE);
+    });
+}
+
+function createTrafficSplitObject(kubectl: Kubectl ,name: string, nextLabel: string): any {
+    // getting smi spec api version 
+    trafficSplitAPIVersion = kubectlUtils.getTrafficSplitAPIVersion(kubectl);
+
+    // deciding weights based on nextlabel
+    let stableWeight: number;
+    let greenWeight: number;
+    if (nextLabel === BLUE_GREEN_NEW_LABEL_VALUE) {
+        stableWeight = parseInt(MIN_VAL);
+        greenWeight = parseInt(MAX_VAL);
+    } else {
+        stableWeight = parseInt(MAX_VAL);
+        greenWeight = parseInt(MIN_VAL);
+    }
+
+    //traffic split json
+    const trafficSplitObjectJson = `{
+        "apiVersion": "${trafficSplitAPIVersion}",
+        "kind": "TrafficSplit",
+        "metadata": {
+            "name": "${getBlueGreenResourceName(name, TRAFFIC_SPLIT_OBJECT_NAME_SUFFIX)}"
+        },
+        "spec": {
+            "service": "${name}",
+            "backends": [
+                {
+                    "service": "${getBlueGreenResourceName(name, STABLE_SUFFIX)}",
+                    "weight": ${stableWeight}
+                },
+                {
+                    "service": "${getBlueGreenResourceName(name, BLUE_GREEN_SUFFIX)}",
+                    "weight": ${greenWeight}
+                }
+            ]
+        }
+    }`;
+    let trafficSplitObject = util.format(trafficSplitObjectJson);
+
+    // creaeting trafficplit object
+    trafficSplitObject = fileHelper.writeManifestToFile(trafficSplitObject, TRAFFIC_SPLIT_OBJECT, getBlueGreenResourceName(name, TRAFFIC_SPLIT_OBJECT_NAME_SUFFIX));
+    kubectl.apply(trafficSplitObject);
+}
+
+export function getSMIServiceResource(inputObject: any, suffix: string, replicas?: number): object {
+    const newObject = JSON.parse(JSON.stringify(inputObject));
+    if (suffix === STABLE_SUFFIX) {
+        // adding stable suffix to service name
+        newObject.metadata.name = getBlueGreenResourceName(inputObject.metadata.name, STABLE_SUFFIX)
+        return getNewBlueGreenObject(newObject, replicas, NONE_LABEL_VALUE);
+    } else {
+        // green label will be added for these
+        return getNewBlueGreenObject(newObject, replicas, BLUE_GREEN_NEW_LABEL_VALUE);
+    }
+}
+
+export function blueGreenRouteTraffic(kubectl: Kubectl, nextLabel: string, deploymentEntityList: any[], serviceEntityList: any[]) {
+    
+    serviceEntityList.forEach((inputObject) => {
+        deploymentEntityList.forEach((depObject) => {
+            // finding out whether service targets a deployment in given manifests
+            if (getServiceSelector(inputObject) && getDeploymentMatchLabels(depObject) && getServiceSelector(inputObject) === getDeploymentMatchLabels(depObject)) {
+                // decided that this service needs to be routed
+                // point to blue green entities
+                createTrafficSplitObject(kubectl, inputObject.metadata.name, nextLabel);
+            }
+        });
+    });
+}
+
+export function validateTrafficSplitState(kubectl: Kubectl, deploymentEntityList: any[], serviceEntityList: any[]): boolean {
+    
+    let isTrafficSplitInRightState: boolean = true;
+    serviceEntityList.forEach((inputObject) => {
+        const name: string = inputObject.metadata.name;  
+        deploymentEntityList.forEach((depObject) => {
+            // seeing if given service targets a corresponding deployment in given manifest
+            if (getServiceSelector(inputObject) && getDeploymentMatchLabels(depObject) && getServiceSelector(inputObject) === getDeploymentMatchLabels(depObject)) {
+                // querying existing trafficsplit object
+                let trafficSplitObject = fetchResource(kubectl, TRAFFIC_SPLIT_OBJECT, name+TRAFFIC_SPLIT_OBJECT_NAME_SUFFIX);
+                if (!trafficSplitObject) {
+                    // no trafficplit exits
+                    isTrafficSplitInRightState = false;
+                }
+                trafficSplitObject = JSON.parse(JSON.stringify(trafficSplitObject));
+                trafficSplitObject.spec.backends.forEach(element => {
+                    // checking if trafficsplit in right state to deploy
+                    if (element.service === name+BLUE_GREEN_SUFFIX) {
+                        if (element.weight == MAX_VAL) {
+                        } else {
+                            // green service should have max weight
+                            isTrafficSplitInRightState = false;
+                        }
+                    } 
+
+                    if (element.service === name+STABLE_SUFFIX) {
+                        if (element.weight == MIN_VAL) {
+                        } else {
+                            // stable service should have 0 weight
+                            isTrafficSplitInRightState = false;
+                        }
+                    } 
+                });
+            }
+        });
+    });               
+    
+    return isTrafficSplitInRightState;
+}
+
+export function cleanSetUpSMI(kubectl: Kubectl, deploymentEntityList: any[], serviceEntityList: any[]) {
+    
+    const delList = [];
+    serviceEntityList.forEach((inputObject) => {
+        deploymentEntityList.forEach((depObject) => {
+            // finding out whether service targets a deployment in given manifests
+            if (getServiceSelector(inputObject) && getDeploymentMatchLabels(depObject) && getServiceSelector(inputObject) === getDeploymentMatchLabels(depObject)) {
+                delList.push({name: inputObject.metadata.name+BLUE_GREEN_SUFFIX, kind: inputObject.kind});
+                delList.push({name: inputObject.metadata.name+STABLE_SUFFIX, kind: inputObject.kind});
+                delList.push({name: inputObject.metadata.name+TRAFFIC_SPLIT_OBJECT_NAME_SUFFIX, kind: TRAFFIC_SPLIT_OBJECT});
+            }
+        });
+    });
+
+    // deleting all objects
+    delList.forEach((delObject) => {
+        try {
+            const result = kubectl.delete([delObject.kind, delObject.name]);
+            checkForErrors([result]);
+        } catch (ex) {
+            // Ignore failures of delete if doesn't exist
+        }
+    });
+}

--- a/src/utilities/strategy-helpers/smi-blue-green-helper.ts
+++ b/src/utilities/strategy-helpers/smi-blue-green-helper.ts
@@ -44,7 +44,7 @@ export async function promoteBlueGreenSMI(kubectl: Kubectl, manifestObjects) {
     return result;
 }
 
-export async function blueGreenRejectSMI(kubectl: Kubectl, filePaths: string[]) {
+export async function rejectBlueGreenSMI(kubectl: Kubectl, filePaths: string[]) {
     // get all kubernetes objects defined in manifest files
     const manifestObjects = getManifestObjects(filePaths);
 


### PR DESCRIPTION
Like the existing canary deployment strategy, added blue-green deployment strategy to the actions with three route-methods - service, ingress and smi. also added version-switch-buffer input takes input in minutes. It waits for the given time before routing service/ingress/trafficsplit to new deployments in deploy step. 

Reference image for how service routing should work.
![service-diagram](https://user-images.githubusercontent.com/33158091/86126334-c00f3080-bafb-11ea-89d6-db29934fc855.jpg)
