### PR TITLE
Add yaml parser to image substitution logic

### DIFF
--- a/lib/input-parameters.js
+++ b/lib/input-parameters.js
@@ -4,7 +4,8 @@ exports.githubToken = exports.forceDeployment = exports.args = exports.baselineA
 const core = require("@actions/core");
 const utility_1 = require("./utilities/utility");
 exports.namespace = core.getInput('namespace');
-exports.containers = core.getInput('images').split('\n');
+exports.containers = core.getInput('images').split('\n').filter(image => image.trim().length > 0);
+;
 exports.imagePullSecrets = core.getInput('imagepullsecrets').split('\n').filter(secret => secret.trim().length > 0);
 exports.manifests = utility_1.resolveGlobPatterns(core.getInput('manifests'));
 exports.canaryPercentage = core.getInput('percentage');

--- a/lib/utilities/manifest-utilities.js
+++ b/lib/utilities/manifest-utilities.js
@@ -13,7 +13,6 @@ exports.isWorkloadEntity = exports.getUpdatedManifestFiles = exports.updateImage
 const core = require("@actions/core");
 const fs = require("fs");
 const yaml = require("js-yaml");
-const path = require("path");
 const kubectlutility = require("./kubectl-util");
 const io = require("@actions/io");
 const utility_1 = require("./utility");
@@ -73,30 +72,61 @@ exports.getDeleteCmdArgs = getDeleteCmdArgs;
     This substituteImageNameInSpecFile function would return
         return Value: `image: "example/example-image:identifiertag"`
 */
-function substituteImageNameInSpecFile(currentString, imageName, imageNameWithNewTag) {
-    if (currentString.indexOf(imageName) < 0) {
-        core.debug(`No occurence of replacement token: ${imageName} found`);
-        return currentString;
+function substituteImageNameInSpecFile(inputObject, containers) {
+    if (!inputObject || !inputObject.spec || !containers) {
+        return;
     }
-    return currentString.split('\n').reduce((acc, line) => {
-        const imageKeyword = line.match(/^ *image:/);
-        if (imageKeyword) {
-            let [currentImageName, currentImageTag] = line
-                .substring(imageKeyword[0].length) // consume the line from keyword onwards
-                .trim()
-                .replace(/[',"]/g, '') // replace allowed quotes with nothing
-                .split(':');
-            if (!currentImageTag && currentImageName.indexOf(' ') > 0) {
-                currentImageName = currentImageName.split(' ')[0]; // Stripping off comments
-            }
-            if (currentImageName === imageName) {
-                return acc + `${imageKeyword[0]} ${imageNameWithNewTag}\n`;
-            }
+    if (inputObject.spec.template && !!inputObject.spec.template.spec) {
+        if (inputObject.spec.template.spec.containers) {
+            updateContainers(inputObject.spec.template.spec.containers, containers);
         }
-        return acc + line + '\n';
-    }, '');
+        if (inputObject.spec.template.spec.initContainers) {
+            updateContainers(inputObject.spec.template.spec.initContainers, containers);
+        }
+        return;
+    }
+    if (inputObject.spec.jobTemplate && inputObject.spec.jobTemplate.spec && inputObject.spec.jobTemplate.spec.template && inputObject.spec.jobTemplate.spec.template.spec) {
+        if (inputObject.spec.jobTemplate.spec.template.spec.containers) {
+            updateContainers(inputObject.spec.jobTemplate.spec.template.spec.containers, containers);
+        }
+        if (inputObject.spec.jobTemplate.spec.template.spec.initContainers) {
+            updateContainers(inputObject.spec.jobTemplate.spec.template.spec.initContainers, containers);
+        }
+        return;
+    }
+    if (inputObject.spec.containers) {
+        updateContainers(inputObject.spec.containers, containers);
+    }
+    if (inputObject.spec.initContainers) {
+        updateContainers(inputObject.spec.initContainers, containers);
+    }
 }
 exports.substituteImageNameInSpecFile = substituteImageNameInSpecFile;
+function updateContainers(inputContainers, images) {
+    if (!inputContainers || inputContainers.length === 0) {
+        return inputContainers;
+    }
+    inputContainers.forEach((inputContainer) => {
+        const imageName = extractImageName(inputContainer.image.trim());
+        images.forEach(image => {
+            if (extractImageName(image) === imageName) {
+                inputContainer.image = image;
+            }
+        });
+    });
+}
+function extractImageName(imageName) {
+    let img = '';
+    if (imageName.indexOf('/') > 0) {
+        const registry = imageName.substring(0, imageName.indexOf('/'));
+        const imgName = imageName.substring(imageName.indexOf('/') + 1).split(':')[0];
+        img = `${registry}/${imgName}`;
+    }
+    else {
+        img = imageName.split(':')[0];
+    }
+    return img;
+}
 function createInlineArray(str) {
     if (typeof str === 'string') {
         return str;
@@ -197,23 +227,28 @@ function substituteImageNameInSpecContent(currentString, imageName, imageNameWit
 }
 function updateContainerImagesInManifestFiles(filePaths, containers) {
     if (!!containers && containers.length > 0) {
-        const newFilePaths = [];
+        const newObjectsList = [];
         const tempDirectory = fileHelper.getTempDirectory();
         filePaths.forEach((filePath) => {
-            let contents = fs.readFileSync(filePath).toString();
-            containers.forEach((container) => {
-                let imageName = container.split(':')[0];
-                if (imageName.indexOf('@') > 0) {
-                    imageName = imageName.split('@')[0];
-                }
-                if (contents.indexOf(imageName) > 0) {
-                    contents = substituteImageNameInSpecFile(contents, imageName, container);
+            const fileContents = fs.readFileSync(filePath).toString();
+            yaml.safeLoadAll(fileContents, function (inputObject) {
+                if (!!inputObject && !!inputObject.kind) {
+                    const kind = inputObject.kind;
+                    if (KubernetesObjectUtility.isWorkloadEntity(kind)) {
+                        substituteImageNameInSpecFile(inputObject, containers);
+                    }
+                    else if (utility_1.isEqual(kind, 'list', true)) {
+                        let items = inputObject.items;
+                        if (items.length > 0) {
+                            items.forEach((item) => substituteImageNameInSpecFile(item, containers));
+                        }
+                    }
+                    newObjectsList.push(inputObject);
                 }
             });
-            const fileName = path.join(tempDirectory, path.basename(filePath));
-            fs.writeFileSync(path.join(fileName), contents);
-            newFilePaths.push(fileName);
         });
+        core.debug('New K8s objects after updating container images are :' + JSON.stringify(newObjectsList));
+        const newFilePaths = fileHelper.writeObjectsToFile(newObjectsList);
         return newFilePaths;
     }
     return filePaths;

--- a/lib/utilities/manifest-utilities.js
+++ b/lib/utilities/manifest-utilities.js
@@ -9,7 +9,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     });
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.isWorkloadEntity = exports.getUpdatedManifestFiles = exports.updateImagePullSecrets = exports.substituteImageNameInSpecFile = exports.getDeleteCmdArgs = exports.createKubectlArgs = exports.getKubectl = exports.getManifestFiles = void 0;
+exports.isWorkloadEntity = exports.getUpdatedManifestFiles = exports.updateImagePullSecrets = exports.getDeleteCmdArgs = exports.createKubectlArgs = exports.getKubectl = exports.getManifestFiles = void 0;
 const core = require("@actions/core");
 const fs = require("fs");
 const yaml = require("js-yaml");
@@ -72,61 +72,6 @@ exports.getDeleteCmdArgs = getDeleteCmdArgs;
     This substituteImageNameInSpecFile function would return
         return Value: `image: "example/example-image:identifiertag"`
 */
-function substituteImageNameInSpecFile(inputObject, containers) {
-    if (!inputObject || !inputObject.spec || !containers) {
-        return;
-    }
-    if (inputObject.spec.template && !!inputObject.spec.template.spec) {
-        if (inputObject.spec.template.spec.containers) {
-            updateContainers(inputObject.spec.template.spec.containers, containers);
-        }
-        if (inputObject.spec.template.spec.initContainers) {
-            updateContainers(inputObject.spec.template.spec.initContainers, containers);
-        }
-        return;
-    }
-    if (inputObject.spec.jobTemplate && inputObject.spec.jobTemplate.spec && inputObject.spec.jobTemplate.spec.template && inputObject.spec.jobTemplate.spec.template.spec) {
-        if (inputObject.spec.jobTemplate.spec.template.spec.containers) {
-            updateContainers(inputObject.spec.jobTemplate.spec.template.spec.containers, containers);
-        }
-        if (inputObject.spec.jobTemplate.spec.template.spec.initContainers) {
-            updateContainers(inputObject.spec.jobTemplate.spec.template.spec.initContainers, containers);
-        }
-        return;
-    }
-    if (inputObject.spec.containers) {
-        updateContainers(inputObject.spec.containers, containers);
-    }
-    if (inputObject.spec.initContainers) {
-        updateContainers(inputObject.spec.initContainers, containers);
-    }
-}
-exports.substituteImageNameInSpecFile = substituteImageNameInSpecFile;
-function updateContainers(inputContainers, images) {
-    if (!inputContainers || inputContainers.length === 0) {
-        return inputContainers;
-    }
-    inputContainers.forEach((inputContainer) => {
-        const imageName = extractImageName(inputContainer.image.trim());
-        images.forEach(image => {
-            if (extractImageName(image) === imageName) {
-                inputContainer.image = image;
-            }
-        });
-    });
-}
-function extractImageName(imageName) {
-    let img = '';
-    if (imageName.indexOf('/') > 0) {
-        const registry = imageName.substring(0, imageName.indexOf('/'));
-        const imgName = imageName.substring(imageName.indexOf('/') + 1).split(':')[0];
-        img = `${registry}/${imgName}`;
-    }
-    else {
-        img = imageName.split(':')[0];
-    }
-    return img;
-}
 function createInlineArray(str) {
     if (typeof str === 'string') {
         return str;
@@ -225,34 +170,6 @@ function substituteImageNameInSpecContent(currentString, imageName, imageNameWit
         return acc + line + '\n';
     }, '');
 }
-function updateContainerImagesInManifestFiles(filePaths, containers) {
-    if (!!containers && containers.length > 0) {
-        const newObjectsList = [];
-        const tempDirectory = fileHelper.getTempDirectory();
-        filePaths.forEach((filePath) => {
-            const fileContents = fs.readFileSync(filePath).toString();
-            yaml.safeLoadAll(fileContents, function (inputObject) {
-                if (!!inputObject && !!inputObject.kind) {
-                    const kind = inputObject.kind;
-                    if (KubernetesObjectUtility.isWorkloadEntity(kind)) {
-                        substituteImageNameInSpecFile(inputObject, containers);
-                    }
-                    else if (utility_1.isEqual(kind, 'list', true)) {
-                        let items = inputObject.items;
-                        if (items.length > 0) {
-                            items.forEach((item) => substituteImageNameInSpecFile(item, containers));
-                        }
-                    }
-                    newObjectsList.push(inputObject);
-                }
-            });
-        });
-        core.debug('New K8s objects after updating container images are :' + JSON.stringify(newObjectsList));
-        const newFilePaths = fileHelper.writeObjectsToFile(newObjectsList);
-        return newFilePaths;
-    }
-    return filePaths;
-}
 function updateImagePullSecrets(inputObject, newImagePullSecrets) {
     if (!inputObject || !inputObject.spec || !newImagePullSecrets) {
         return;
@@ -272,22 +189,40 @@ function updateImagePullSecrets(inputObject, newImagePullSecrets) {
     setImagePullSecrets(inputObject, existingImagePullSecretObjects);
 }
 exports.updateImagePullSecrets = updateImagePullSecrets;
-function updateImagePullSecretsInManifestFiles(filePaths, imagePullSecrets) {
-    if (!!imagePullSecrets && imagePullSecrets.length > 0) {
-        const newObjectsList = [];
+function updateResourceObjects(filePaths, imagePullSecrets, containers) {
+    if ((!!imagePullSecrets && imagePullSecrets.length > 0) || (!!containers && containers.length > 0)) {
+        let newObjectsList = [];
         filePaths.forEach((filePath) => {
             const fileContents = fs.readFileSync(filePath).toString();
             yaml.safeLoadAll(fileContents, function (inputObject) {
                 if (!!inputObject && !!inputObject.kind) {
                     const kind = inputObject.kind;
                     if (KubernetesObjectUtility.isWorkloadEntity(kind)) {
-                        KubernetesObjectUtility.updateImagePullSecrets(inputObject, imagePullSecrets, false);
+                        if (!!imagePullSecrets && imagePullSecrets.length > 0) {
+                            KubernetesObjectUtility.updateImagePullSecrets(inputObject, imagePullSecrets, false);
+                        }
+                        if (!!containers && containers.length > 0) {
+                            KubernetesObjectUtility.substituteImageNameInSpecFile(inputObject, containers);
+                        }
+                    }
+                    else if (utility_1.isEqual(kind, 'list', true)) {
+                        let items = inputObject.items;
+                        if (items.length > 0) {
+                            items.forEach((item) => {
+                                if (!!imagePullSecrets && imagePullSecrets.length > 0) {
+                                    KubernetesObjectUtility.updateImagePullSecrets(item, imagePullSecrets, false);
+                                }
+                                if (!!containers && containers.length > 0) {
+                                    KubernetesObjectUtility.substituteImageNameInSpecFile(item, containers);
+                                }
+                            });
+                        }
                     }
                     newObjectsList.push(inputObject);
                 }
             });
         });
-        core.debug('New K8s objects after adding imagePullSecrets are :' + JSON.stringify(newObjectsList));
+        core.debug('New K8s objects after adding imagePullSecrets and updating container images are :' + JSON.stringify(newObjectsList));
         const newFilePaths = fileHelper.writeObjectsToFile(newObjectsList);
         return newFilePaths;
     }
@@ -298,10 +233,7 @@ function getUpdatedManifestFiles(manifestFilePaths) {
     if (!inputManifestFiles || inputManifestFiles.length === 0) {
         throw new Error(`ManifestFileNotFound : ${manifestFilePaths}`);
     }
-    // artifact substitution
-    inputManifestFiles = updateContainerImagesInManifestFiles(inputManifestFiles, TaskInputParameters.containers);
-    // imagePullSecrets addition
-    inputManifestFiles = updateImagePullSecretsInManifestFiles(inputManifestFiles, TaskInputParameters.imagePullSecrets);
+    inputManifestFiles = updateResourceObjects(inputManifestFiles, TaskInputParameters.imagePullSecrets, TaskInputParameters.containers);
     return inputManifestFiles;
 }
 exports.getUpdatedManifestFiles = getUpdatedManifestFiles;

--- a/lib/utilities/resource-object-utility.js
+++ b/lib/utilities/resource-object-utility.js
@@ -1,6 +1,6 @@
 'use strict';
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.getResources = exports.updateSelectorLabels = exports.updateSpecLabels = exports.updateImagePullSecrets = exports.updateObjectAnnotations = exports.updateObjectLabels = exports.getReplicaCount = exports.isIngressEntity = exports.isServiceEntity = exports.isWorkloadEntity = exports.isDeploymentEntity = void 0;
+exports.substituteImageNameInSpecFile = exports.getResources = exports.updateSelectorLabels = exports.updateSpecLabels = exports.updateImagePullSecrets = exports.updateObjectAnnotations = exports.updateObjectLabels = exports.getReplicaCount = exports.isIngressEntity = exports.isServiceEntity = exports.isWorkloadEntity = exports.isDeploymentEntity = void 0;
 const fs = require("fs");
 const core = require("@actions/core");
 const yaml = require("js-yaml");
@@ -195,6 +195,61 @@ function getResources(filePaths, filterResourceTypes) {
     return resources;
 }
 exports.getResources = getResources;
+function substituteImageNameInSpecFile(inputObject, containers) {
+    if (!inputObject || !inputObject.spec || !containers) {
+        return;
+    }
+    if (inputObject.spec.template && !!inputObject.spec.template.spec) {
+        if (inputObject.spec.template.spec.containers) {
+            updateContainers(inputObject.spec.template.spec.containers, containers);
+        }
+        if (inputObject.spec.template.spec.initContainers) {
+            updateContainers(inputObject.spec.template.spec.initContainers, containers);
+        }
+        return;
+    }
+    if (inputObject.spec.jobTemplate && inputObject.spec.jobTemplate.spec && inputObject.spec.jobTemplate.spec.template && inputObject.spec.jobTemplate.spec.template.spec) {
+        if (inputObject.spec.jobTemplate.spec.template.spec.containers) {
+            updateContainers(inputObject.spec.jobTemplate.spec.template.spec.containers, containers);
+        }
+        if (inputObject.spec.jobTemplate.spec.template.spec.initContainers) {
+            updateContainers(inputObject.spec.jobTemplate.spec.template.spec.initContainers, containers);
+        }
+        return;
+    }
+    if (inputObject.spec.containers) {
+        updateContainers(inputObject.spec.containers, containers);
+    }
+    if (inputObject.spec.initContainers) {
+        updateContainers(inputObject.spec.initContainers, containers);
+    }
+}
+exports.substituteImageNameInSpecFile = substituteImageNameInSpecFile;
+function updateContainers(inputContainers, images) {
+    if (!inputContainers || inputContainers.length === 0) {
+        return inputContainers;
+    }
+    inputContainers.forEach((inputContainer) => {
+        const imageName = extractImageName(inputContainer.image.trim());
+        images.forEach(image => {
+            if (extractImageName(image) === imageName) {
+                inputContainer.image = image;
+            }
+        });
+    });
+}
+function extractImageName(imageName) {
+    let img = '';
+    if (imageName.indexOf('/') > 0) {
+        const registry = imageName.substring(0, imageName.indexOf('/'));
+        const imgName = imageName.substring(imageName.indexOf('/') + 1).split(':')[0];
+        img = `${registry}/${imgName}`;
+    }
+    else {
+        img = imageName.split(':')[0];
+    }
+    return img;
+}
 function getSpecLabels(inputObject) {
     if (!inputObject) {
         return null;

--- a/src/input-parameters.ts
+++ b/src/input-parameters.ts
@@ -4,7 +4,7 @@ import * as core from '@actions/core';
 import { resolveGlobPatterns } from './utilities/utility';
 
 export let namespace: string = core.getInput('namespace');
-export const containers: string[] = core.getInput('images').split('\n');
+export const containers: string[] = core.getInput('images').split('\n').filter(image => image.trim().length > 0);;
 export const imagePullSecrets: string[] = core.getInput('imagepullsecrets').split('\n').filter(secret => secret.trim().length > 0);
 export const manifests = resolveGlobPatterns(core.getInput('manifests'));
 export const canaryPercentage: string = core.getInput('percentage');


### PR DESCRIPTION
- Fixes #86 
- Added yaml parser an combined the functions for image pull secrets and image substitution
- Fixed input parameter logic to handle empty value for images (currently it was taking it as [' '] instead of [])
- Fixed L0s which were not working because of the new changes