### PR TITLE
Updated deploymentConfig fetch to be called once, populate manifests …

### DIFF
--- a/lib/actions/promote.js
+++ b/lib/actions/promote.js
@@ -27,6 +27,7 @@ const ingress_blue_green_helper_1 = require("../utilities/strategy-helpers/ingre
 const smi_blue_green_helper_1 = require("../utilities/strategy-helpers/smi-blue-green-helper");
 const kubectl_object_model_1 = require("../kubectl-object-model");
 const AzureTraceabilityHelper = require("../traceability/azure-traceability-helper");
+const utility_1 = require("../utilities/utility");
 function promote() {
     return __awaiter(this, void 0, void 0, function* () {
         const kubectl = new kubectl_object_model_1.Kubectl(yield utils.getKubectl(), TaskInputParameters.namespace, true);
@@ -35,13 +36,14 @@ function promote() {
         }
         else if (blue_green_helper_2.isBlueGreenDeploymentStrategy()) {
             yield promoteBlueGreen(kubectl);
+            // Adding traceability data
+            const deploymentConfig = yield utility_1.getDeploymentConfig();
+            yield AzureTraceabilityHelper.addTraceability(kubectl, deploymentConfig);
         }
         else {
             core.debug('Strategy is not canary or blue-green deployment. Invalid request.');
             throw ('InvalidPromotetActionDeploymentStrategy');
         }
-        // Adding traceability data
-        yield AzureTraceabilityHelper.addTraceability(kubectl);
     });
 }
 exports.promote = promote;

--- a/lib/actions/reject.js
+++ b/lib/actions/reject.js
@@ -22,6 +22,7 @@ const smi_blue_green_helper_1 = require("../utilities/strategy-helpers/smi-blue-
 const blue_green_helper_1 = require("../utilities/strategy-helpers/blue-green-helper");
 const deployment_helper_1 = require("../utilities/strategy-helpers/deployment-helper");
 const AzureTraceabilityHelper = require("../traceability/azure-traceability-helper");
+const utility_1 = require("../utilities/utility");
 function reject() {
     return __awaiter(this, void 0, void 0, function* () {
         const kubectl = new kubectl_object_model_1.Kubectl(yield utils.getKubectl(), TaskInputParameters.namespace, true);
@@ -36,7 +37,8 @@ function reject() {
             throw ('InvalidDeletetActionDeploymentStrategy');
         }
         // Adding traceability data
-        yield AzureTraceabilityHelper.addTraceability(kubectl);
+        const deploymentConfig = yield utility_1.getDeploymentConfig();
+        yield AzureTraceabilityHelper.addTraceability(kubectl, deploymentConfig);
     });
 }
 exports.reject = reject;

--- a/lib/traceability/azure-traceability-helper.js
+++ b/lib/traceability/azure-traceability-helper.js
@@ -18,7 +18,6 @@ const InputParameters = require("../input-parameters");
 const core = require("@actions/core");
 const utility_1 = require("../utilities/utility");
 const kubeconfig_utility_1 = require("../utilities/kubeconfig-utility");
-const utility_2 = require("../utilities/utility");
 const AKS_RESOURCE_TYPE = 'Microsoft.ContainerService/ManagedClusters';
 function getAksResourceContext() {
     const runnerTempDirectory = process.env['RUNNER_TEMP'];
@@ -72,10 +71,10 @@ function createDeploymentResource(aksResourceContext, deploymentPayload) {
         });
     });
 }
-function addTraceability(kubectl) {
+function addTraceability(kubectl, deploymentConfig) {
     return __awaiter(this, void 0, void 0, function* () {
         try {
-            const deploymentReport = yield createDeploymentReport(kubectl);
+            const deploymentReport = yield createDeploymentReport(kubectl, deploymentConfig);
             const aksResourceContext = getAksResourceContext();
             if (aksResourceContext !== null) {
                 const deploymentPayload = getDeploymentPayload(deploymentReport, aksResourceContext);
@@ -96,12 +95,11 @@ function getAksResourceId(aksResourceContext) {
 }
 function getDeploymentResourceUri(aksResourceContext) {
     // TODO: Finalize the right resource name.
-    const deploymentName = `${aksResourceContext.clusterName}-${InputParameters.namespace}-deployment-${utility_2.getRandomGuid()}`;
+    const deploymentName = `${aksResourceContext.clusterName}-${InputParameters.namespace}-deployment-${utility_1.getRandomGuid()}`;
     return `${aksResourceContext.managementUrl}subscriptions/${aksResourceContext.subscriptionId}/resourceGroups/${aksResourceContext.resourceGroup}/providers/Microsoft.Devops/deploymentdetails/${deploymentName}?api-version=2020-12-01-preview`;
 }
-function createDeploymentReport(kubectl) {
+function createDeploymentReport(kubectl, deploymentConfig) {
     return __awaiter(this, void 0, void 0, function* () {
-        const deploymentConfig = yield utility_1.getDeploymentConfig();
         const clusterMetadata = kubeconfig_utility_1.getClusterMetadata();
         const resource = {
             type: 'kubernetes',

--- a/lib/utilities/strategy-helpers/deployment-helper.js
+++ b/lib/utilities/strategy-helpers/deployment-helper.js
@@ -56,8 +56,9 @@ function deploy(kubectl, manifestFilePaths, deploymentStrategy) {
         catch (e) {
             core.debug("Unable to parse pods; Error: " + e);
         }
-        yield annotateAndLabelResources(deployedManifestFiles, kubectl, resourceTypes, allPods);
-        yield AzureTraceabilityHelper.addTraceability(kubectl);
+        const deploymentConfig = yield utility_1.getDeploymentConfig();
+        yield annotateAndLabelResources(deployedManifestFiles, kubectl, resourceTypes, allPods, deploymentConfig);
+        yield AzureTraceabilityHelper.addTraceability(kubectl, deploymentConfig);
     });
 }
 exports.deploy = deploy;
@@ -133,10 +134,9 @@ function checkManifestStability(kubectl, resources) {
         yield KubernetesManifestUtility.checkManifestStability(kubectl, resources);
     });
 }
-function annotateAndLabelResources(files, kubectl, resourceTypes, allPods) {
+function annotateAndLabelResources(files, kubectl, resourceTypes, allPods, deploymentConfig) {
     return __awaiter(this, void 0, void 0, function* () {
         const workflowFilePath = yield utility_1.getWorkflowFilePath(TaskInputParameters.githubToken);
-        const deploymentConfig = yield utility_1.getDeploymentConfig();
         const annotationKeyLabel = models.getWorkflowAnnotationKeyLabel(workflowFilePath);
         annotateResources(files, kubectl, resourceTypes, allPods, annotationKeyLabel, workflowFilePath, deploymentConfig);
         labelResources(files, kubectl, annotationKeyLabel);

--- a/lib/utilities/utility.js
+++ b/lib/utilities/utility.js
@@ -146,20 +146,27 @@ function getDeploymentConfig() {
     return __awaiter(this, void 0, void 0, function* () {
         let helmChartPaths = (process.env.HELM_CHART_PATHS && process.env.HELM_CHART_PATHS.split(';').filter(path => path != "")) || [];
         helmChartPaths = helmChartPaths.map(helmchart => getNormalizedPath(helmchart.trim()));
-        let inputManifestFiles = inputParams.manifests || [];
+        let inputManifestFiles = [];
         if (!helmChartPaths.length) {
+            inputManifestFiles = inputParams.manifests || [];
             inputManifestFiles = inputManifestFiles.map(manifestFile => getNormalizedPath(manifestFile));
         }
         const imageNames = inputParams.containers || [];
         let imageDockerfilePathMap = {};
-        //Fetching from image label if available
-        for (const image of imageNames) {
-            try {
-                imageDockerfilePathMap[image] = yield getDockerfilePath(image);
+        try {
+            yield checkDockerPath();
+            //Fetching from image label if available
+            for (const image of imageNames) {
+                try {
+                    imageDockerfilePathMap[image] = yield getDockerfilePath(image);
+                }
+                catch (ex) {
+                    core.warning(`Failed to get dockerfile path for image ${image.toString()} | ` + ex);
+                }
             }
-            catch (ex) {
-                core.warning(`Failed to get dockerfile path for image ${image.toString()} | ` + ex);
-            }
+        }
+        catch (ex) {
+            core.warning(`Failed to get dockerfile path for images | ` + ex);
         }
         const deploymentConfig = {
             manifestFilePaths: inputManifestFiles,
@@ -198,7 +205,6 @@ function getDockerfilePath(image) {
     return __awaiter(this, void 0, void 0, function* () {
         let imageConfig, imageInspectResult;
         var dockerExec = new docker_object_model_1.DockerExec('docker');
-        yield checkDockerPath();
         dockerExec.pull(image, [], true);
         imageInspectResult = dockerExec.inspect(image, [], true);
         imageConfig = JSON.parse(imageInspectResult)[0];

--- a/src/actions/reject.ts
+++ b/src/actions/reject.ts
@@ -11,6 +11,7 @@ import { rejectBlueGreenSMI } from '../utilities/strategy-helpers/smi-blue-green
 import { isSMIRoute, isIngressRoute, isBlueGreenDeploymentStrategy } from '../utilities/strategy-helpers/blue-green-helper'
 import { getManifestFiles } from '../utilities/strategy-helpers/deployment-helper'
 import * as AzureTraceabilityHelper from "../traceability/azure-traceability-helper";
+import { getDeploymentConfig } from '../utilities/utility';
 
 export async function reject() {
     const kubectl = new Kubectl(await utils.getKubectl(), TaskInputParameters.namespace, true);
@@ -25,7 +26,8 @@ export async function reject() {
     }
 
     // Adding traceability data
-    await AzureTraceabilityHelper.addTraceability(kubectl);
+    const deploymentConfig = await getDeploymentConfig();
+    await AzureTraceabilityHelper.addTraceability(kubectl, deploymentConfig);
 }
 
 async function rejectCanary(kubectl: Kubectl) {
@@ -42,7 +44,7 @@ async function rejectCanary(kubectl: Kubectl) {
 
 async function rejectBlueGreen(kubectl: Kubectl) {
     let inputManifestFiles: string[] = getManifestFiles(TaskInputParameters.manifests);
-    if(isIngressRoute()) {
+    if (isIngressRoute()) {
         await rejectBlueGreenIngress(kubectl, inputManifestFiles);
     } else if (isSMIRoute()) {
         await rejectBlueGreenSMI(kubectl, inputManifestFiles);

--- a/src/traceability/azure-traceability-helper.ts
+++ b/src/traceability/azure-traceability-helper.ts
@@ -5,9 +5,8 @@ import { WebRequest, WebRequestOptions, WebResponse, sendRequest, StatusCodes } 
 import * as InputParameters from "../input-parameters";
 import * as core from '@actions/core';
 import { Kubectl } from '../kubectl-object-model';
-import { getDeploymentConfig } from '../utilities/utility';
+import { DeploymentConfig, getRandomGuid } from '../utilities/utility';
 import { getClusterMetadata } from '../utilities/kubeconfig-utility';
-import { getRandomGuid } from '../utilities/utility';
 
 const AKS_RESOURCE_TYPE = 'Microsoft.ContainerService/ManagedClusters';
 
@@ -71,9 +70,9 @@ async function createDeploymentResource(aksResourceContext: AksResourceContext, 
   });
 }
 
-export async function addTraceability(kubectl: Kubectl): Promise<void> {
+export async function addTraceability(kubectl: Kubectl, deploymentConfig: DeploymentConfig): Promise<void> {
   try {
-    const deploymentReport = await createDeploymentReport(kubectl);
+    const deploymentReport = await createDeploymentReport(kubectl, deploymentConfig);
     const aksResourceContext = getAksResourceContext();
     if (aksResourceContext !== null) {
       const deploymentPayload = getDeploymentPayload(deploymentReport, aksResourceContext);
@@ -98,8 +97,7 @@ function getDeploymentResourceUri(aksResourceContext: AksResourceContext): strin
   return `${aksResourceContext.managementUrl}subscriptions/${aksResourceContext.subscriptionId}/resourceGroups/${aksResourceContext.resourceGroup}/providers/Microsoft.Devops/deploymentdetails/${deploymentName}?api-version=2020-12-01-preview`;
 }
 
-async function createDeploymentReport(kubectl: Kubectl): Promise<DeploymentReport> {
-  const deploymentConfig = await getDeploymentConfig();
+async function createDeploymentReport(kubectl: Kubectl, deploymentConfig: DeploymentConfig): Promise<DeploymentReport> {
   const clusterMetadata = getClusterMetadata();
   const resource: TargetResource = {
     type: 'kubernetes',

--- a/src/utilities/strategy-helpers/deployment-helper.ts
+++ b/src/utilities/strategy-helpers/deployment-helper.ts
@@ -55,8 +55,9 @@ export async function deploy(kubectl: Kubectl, manifestFilePaths: string[], depl
         core.debug("Unable to parse pods; Error: " + e);
     }
 
-    await annotateAndLabelResources(deployedManifestFiles, kubectl, resourceTypes, allPods);
-    await AzureTraceabilityHelper.addTraceability(kubectl);
+    const deploymentConfig = await getDeploymentConfig();
+    await annotateAndLabelResources(deployedManifestFiles, kubectl, resourceTypes, allPods, deploymentConfig);
+    await AzureTraceabilityHelper.addTraceability(kubectl, deploymentConfig);
 }
 
 export function getManifestFiles(manifestFilePaths: string[]): string[] {
@@ -130,9 +131,8 @@ async function checkManifestStability(kubectl: Kubectl, resources: Resource[]): 
     await KubernetesManifestUtility.checkManifestStability(kubectl, resources);
 }
 
-async function annotateAndLabelResources(files: string[], kubectl: Kubectl, resourceTypes: Resource[], allPods: any) {
+async function annotateAndLabelResources(files: string[], kubectl: Kubectl, resourceTypes: Resource[], allPods: any, deploymentConfig: DeploymentConfig) {
     const workflowFilePath = await getWorkflowFilePath(TaskInputParameters.githubToken);
-    const deploymentConfig = await getDeploymentConfig();
     const annotationKeyLabel = models.getWorkflowAnnotationKeyLabel(workflowFilePath);
     annotateResources(files, kubectl, resourceTypes, allPods, annotationKeyLabel, workflowFilePath, deploymentConfig);
     labelResources(files, kubectl, annotationKeyLabel);


### PR DESCRIPTION
Made changes such that: 
- 'checkDocker' to be called once while fetching deployment config
- 'deploymentConfig' object created once and used for both annotation and deploymentResource
- Manifests array will be empty when helmcharts present.