### PR TITLE
Added arch detection to kubectl download

### DIFF
--- a/lib/utilities/kubectl-util.js
+++ b/lib/utilities/kubectl-util.js
@@ -16,6 +16,7 @@ const os = require("os");
 const path = require("path");
 const toolCache = require("@actions/tool-cache");
 const util = require("util");
+const httpClient_1 = require("./httpClient");
 const kubectlToolName = 'kubectl';
 const stableKubectlVersion = 'v1.15.0';
 const stableVersionUrl = 'https://storage.googleapis.com/kubernetes-release/release/stable.txt';
@@ -26,15 +27,22 @@ function getExecutableExtension() {
     }
     return '';
 }
-function getkubectlDownloadURL(version) {
+function getKubectlArch() {
+    let arch = os.arch();
+    if (arch === 'x64') {
+        return 'amd64';
+    }
+    return arch;
+}
+function getkubectlDownloadURL(version, arch) {
     switch (os.type()) {
         case 'Linux':
-            return util.format('https://storage.googleapis.com/kubernetes-release/release/%s/bin/linux/amd64/kubectl', version);
+            return util.format('https://storage.googleapis.com/kubernetes-release/release/%s/bin/linux/%s/kubectl', version, arch);
         case 'Darwin':
-            return util.format('https://storage.googleapis.com/kubernetes-release/release/%s/bin/darwin/amd64/kubectl', version);
+            return util.format('https://storage.googleapis.com/kubernetes-release/release/%s/bin/darwin/%s/kubectl', version, arch);
         case 'Windows_NT':
         default:
-            return util.format('https://storage.googleapis.com/kubernetes-release/release/%s/bin/windows/amd64/kubectl.exe', version);
+            return util.format('https://storage.googleapis.com/kubernetes-release/release/%s/bin/windows/%s/kubectl.exe', version, arch);
     }
 }
 exports.getkubectlDownloadURL = getkubectlDownloadURL;
@@ -58,12 +66,18 @@ function downloadKubectl(version) {
     return __awaiter(this, void 0, void 0, function* () {
         let cachedToolpath = toolCache.find(kubectlToolName, version);
         let kubectlDownloadPath = '';
+        let arch = getKubectlArch();
         if (!cachedToolpath) {
             try {
-                kubectlDownloadPath = yield toolCache.downloadTool(getkubectlDownloadURL(version));
+                kubectlDownloadPath = yield toolCache.downloadTool(getkubectlDownloadURL(version, arch));
             }
             catch (exception) {
-                throw new Error('DownloadKubectlFailed');
+                if (exception instanceof toolCache.HTTPError && exception.httpStatusCode === httpClient_1.StatusCodes.NOT_FOUND) {
+                    throw new Error(util.format("Kubectl '%s' for '%s' arch not found.", version, arch));
+                }
+                else {
+                    throw new Error('DownloadKubectlFailed');
+                }
             }
             cachedToolpath = yield toolCache.cacheFile(kubectlDownloadPath, kubectlToolName + getExecutableExtension(), kubectlToolName, version);
         }

--- a/src/utilities/kubectl-util.ts
+++ b/src/utilities/kubectl-util.ts
@@ -6,6 +6,7 @@ import * as toolCache from '@actions/tool-cache';
 import * as util from 'util';
 
 import { Kubectl } from '../kubectl-object-model';
+import { StatusCodes } from "./httpClient"
 
 const kubectlToolName = 'kubectl';
 const stableKubectlVersion = 'v1.15.0';
@@ -19,17 +20,25 @@ function getExecutableExtension(): string {
     return '';
 }
 
-export function getkubectlDownloadURL(version: string): string {
+function getKubectlArch(): string {
+    let arch = os.arch();
+    if (arch === 'x64') {
+        return 'amd64';
+    }
+    return arch;
+}
+
+export function getkubectlDownloadURL(version: string, arch: string): string {
     switch (os.type()) {
         case 'Linux':
-            return util.format('https://storage.googleapis.com/kubernetes-release/release/%s/bin/linux/amd64/kubectl', version);
+            return util.format('https://storage.googleapis.com/kubernetes-release/release/%s/bin/linux/%s/kubectl', version, arch);
 
         case 'Darwin':
-            return util.format('https://storage.googleapis.com/kubernetes-release/release/%s/bin/darwin/amd64/kubectl', version);
+            return util.format('https://storage.googleapis.com/kubernetes-release/release/%s/bin/darwin/%s/kubectl', version, arch);
 
         case 'Windows_NT':
         default:
-            return util.format('https://storage.googleapis.com/kubernetes-release/release/%s/bin/windows/amd64/kubectl.exe', version);
+            return util.format('https://storage.googleapis.com/kubernetes-release/release/%s/bin/windows/%s/kubectl.exe', version, arch);
 
     }
 }
@@ -51,11 +60,16 @@ export async function getStableKubectlVersion(): Promise<string> {
 export async function downloadKubectl(version: string): Promise<string> {
     let cachedToolpath = toolCache.find(kubectlToolName, version);
     let kubectlDownloadPath = '';
+    let arch = getKubectlArch();
     if (!cachedToolpath) {
         try {
-            kubectlDownloadPath = await toolCache.downloadTool(getkubectlDownloadURL(version));
+            kubectlDownloadPath = await toolCache.downloadTool(getkubectlDownloadURL(version, arch));
         } catch (exception) {
-            throw new Error('DownloadKubectlFailed');
+            if (exception instanceof toolCache.HTTPError && exception.httpStatusCode === StatusCodes.NOT_FOUND) {
+                throw new Error(util.format("Kubectl '%s' for '%s' arch not found.", version, arch));
+            } else {
+                throw new Error('DownloadKubectlFailed');
+            }
         }
 
         cachedToolpath = await toolCache.cacheFile(kubectlDownloadPath, kubectlToolName + getExecutableExtension(), kubectlToolName, version);


### PR DESCRIPTION
This PR adds the arch detection to kubectl download using [`os.arch()`](https://nodejs.org/api/os.html) call. It won't work on all arch's, but should support amd64, arm and arm64 on Linux (and some more - https://kubernetes.io/docs/setup/release/notes/#client-binaries). If the action is run on non-supported arch by kubectl it won't be able to download and will fail.

Should fix #115. 