### PR TITLE
Supporting both comma and new line as delimiters for manifests

### DIFF
--- a/__tests__/run.test.ts
+++ b/__tests__/run.test.ts
@@ -294,6 +294,27 @@ test("run() - deploy - Manifests provided by both new line and comma as a delimi
     await expect(action.run()).resolves.not.toThrow();
 });
 
+test("run() - deploy - Manifests provided by both new line and comma and semi-colon as a delimiter", async () => {
+    const kubectlVersion = 'v1.18.0'
+    coreMock.getInput = jest.fn().mockImplementation((name) => {
+        if (name == 'manifests') {
+            return "bg-smi.yml\nbg.yml,deployment.yml;bg.yml";
+        }
+        if (name == 'action') {
+            return 'deploy';
+        }
+        return kubectlVersion;
+    });
+    coreMock.setFailed = jest.fn();
+    toolCacheMock.find = jest.fn().mockReturnValue(undefined);
+    toolCacheMock.downloadTool = jest.fn().mockReturnValue('downloadpath');
+    toolCacheMock.cacheFile = jest.fn().mockReturnValue('cachepath');
+    fileUtility.chmodSync = jest.fn();
+
+    //Invoke and assert
+    await expect(action.run()).resolves.not.toThrow();
+});
+
 test("deployment - deploy() - Invokes with no manifestfiles", async () => {
     const kubeCtl: jest.Mocked<Kubectl> = new Kubectl("") as any;
 

--- a/__tests__/run.test.ts
+++ b/__tests__/run.test.ts
@@ -210,11 +210,32 @@ test("run() - deploy - Manifiest not provided", async () => {
     expect(coreMock.setFailed).toBeCalledWith('No manifests supplied to deploy');
 });
 
+test("run() - deploy - Only one manifest with no delimiters", async () => {
+    const kubectlVersion = 'v1.18.0'
+    coreMock.getInput = jest.fn().mockImplementation((name) => {
+        if (name == 'manifests') {
+            return "bg-smi.yml";
+        }
+        if (name == 'action') {
+            return 'deploy';
+        }
+        return kubectlVersion;
+    });
+    coreMock.setFailed = jest.fn();
+    toolCacheMock.find = jest.fn().mockReturnValue(undefined);
+    toolCacheMock.downloadTool = jest.fn().mockReturnValue('downloadpath');
+    toolCacheMock.cacheFile = jest.fn().mockReturnValue('cachepath');
+    fileUtility.chmodSync = jest.fn();
+
+    //Invoke and assert
+    await expect(action.run()).resolves.not.toThrow();
+});
+
 test("run() - deploy - Manifests provided by new line delimiter", async () => {
     const kubectlVersion = 'v1.18.0'
     coreMock.getInput = jest.fn().mockImplementation((name) => {
         if (name == 'manifests') {
-            return "bg-smi.yml\nbg.yml\ndeployment.yml";
+            return "bg-smi.yml\n  bg.yml\ndeployment.yml";
         }
         if (name == 'action') {
             return 'deploy';
@@ -235,7 +256,7 @@ test("run() - deploy - Manifests provided by comma as a delimiter", async () => 
     const kubectlVersion = 'v1.18.0'
     coreMock.getInput = jest.fn().mockImplementation((name) => {
         if (name == 'manifests') {
-            return "bg-smi.yml,bg.yml,deployment.yml";
+            return "bg-smi.yml, bg.yml, deployment.yml";
         }
         if (name == 'action') {
             return 'deploy';

--- a/__tests__/run.test.ts
+++ b/__tests__/run.test.ts
@@ -210,6 +210,69 @@ test("run() - deploy - Manifiest not provided", async () => {
     expect(coreMock.setFailed).toBeCalledWith('No manifests supplied to deploy');
 });
 
+test("run() - deploy - Manifests provided by new line delimiter", async () => {
+    const kubectlVersion = 'v1.18.0'
+    coreMock.getInput = jest.fn().mockImplementation((name) => {
+        if (name == 'manifests') {
+            return "bg-smi.yml\nbg.yml\ndeployment.yml";
+        }
+        if (name == 'action') {
+            return 'deploy';
+        }
+        return kubectlVersion;
+    });
+    coreMock.setFailed = jest.fn();
+    toolCacheMock.find = jest.fn().mockReturnValue(undefined);
+    toolCacheMock.downloadTool = jest.fn().mockReturnValue('downloadpath');
+    toolCacheMock.cacheFile = jest.fn().mockReturnValue('cachepath');
+    fileUtility.chmodSync = jest.fn();
+
+    //Invoke and assert
+    await expect(action.run()).resolves.not.toThrow();
+});
+
+test("run() - deploy - Manifests provided by comma as a delimiter", async () => {
+    const kubectlVersion = 'v1.18.0'
+    coreMock.getInput = jest.fn().mockImplementation((name) => {
+        if (name == 'manifests') {
+            return "bg-smi.yml,bg.yml,deployment.yml";
+        }
+        if (name == 'action') {
+            return 'deploy';
+        }
+        return kubectlVersion;
+    });
+    coreMock.setFailed = jest.fn();
+    toolCacheMock.find = jest.fn().mockReturnValue(undefined);
+    toolCacheMock.downloadTool = jest.fn().mockReturnValue('downloadpath');
+    toolCacheMock.cacheFile = jest.fn().mockReturnValue('cachepath');
+    fileUtility.chmodSync = jest.fn();
+
+    //Invoke and assert
+    await expect(action.run()).resolves.not.toThrow();
+});
+
+test("run() - deploy - Manifests provided by both new line and comma as a delimiter", async () => {
+    const kubectlVersion = 'v1.18.0'
+    coreMock.getInput = jest.fn().mockImplementation((name) => {
+        if (name == 'manifests') {
+            return "bg-smi.yml\nbg.yml,deployment.yml";
+        }
+        if (name == 'action') {
+            return 'deploy';
+        }
+        return kubectlVersion;
+    });
+    coreMock.setFailed = jest.fn();
+    toolCacheMock.find = jest.fn().mockReturnValue(undefined);
+    toolCacheMock.downloadTool = jest.fn().mockReturnValue('downloadpath');
+    toolCacheMock.cacheFile = jest.fn().mockReturnValue('cachepath');
+    fileUtility.chmodSync = jest.fn();
+
+    //Invoke and assert
+    await expect(action.run()).resolves.not.toThrow();
+});
+
 test("deployment - deploy() - Invokes with no manifestfiles", async () => {
     const kubeCtl: jest.Mocked<Kubectl> = new Kubectl("") as any;
 

--- a/src/input-parameters.ts
+++ b/src/input-parameters.ts
@@ -5,7 +5,7 @@ import * as core from '@actions/core';
 export let namespace: string = core.getInput('namespace');
 export const containers: string[] = core.getInput('images').split('\n');
 export const imagePullSecrets: string[] = core.getInput('imagepullsecrets').split('\n').filter(secret => secret.trim().length > 0);
-export const manifests = core.getInput('manifests').split(/[\n,]+/).filter(manifest => manifest.trim().length > 0);
+export const manifests = core.getInput('manifests').split(/[\n,;]+/).filter(manifest => manifest.trim().length > 0);
 export const canaryPercentage: string = core.getInput('percentage');
 export const deploymentStrategy: string = core.getInput('strategy');
 export const trafficSplitMethod: string = core.getInput('traffic-split-method');

--- a/src/input-parameters.ts
+++ b/src/input-parameters.ts
@@ -5,7 +5,7 @@ import * as core from '@actions/core';
 export let namespace: string = core.getInput('namespace');
 export const containers: string[] = core.getInput('images').split('\n');
 export const imagePullSecrets: string[] = core.getInput('imagepullsecrets').split('\n').filter(secret => secret.trim().length > 0);
-export const manifests = core.getInput('manifests').split(/[\n,]+/);
+export const manifests = core.getInput('manifests').split(/[\n,]+/).filter(manifest => manifest.trim().length > 0);
 export const canaryPercentage: string = core.getInput('percentage');
 export const deploymentStrategy: string = core.getInput('strategy');
 export const trafficSplitMethod: string = core.getInput('traffic-split-method');

--- a/src/input-parameters.ts
+++ b/src/input-parameters.ts
@@ -5,7 +5,7 @@ import * as core from '@actions/core';
 export let namespace: string = core.getInput('namespace');
 export const containers: string[] = core.getInput('images').split('\n');
 export const imagePullSecrets: string[] = core.getInput('imagepullsecrets').split('\n').filter(secret => secret.trim().length > 0);
-export const manifests = core.getInput('manifests').split('\n');
+export const manifests = core.getInput('manifests').split(/[\n,]+/);
 export const canaryPercentage: string = core.getInput('percentage');
 export const deploymentStrategy: string = core.getInput('strategy');
 export const trafficSplitMethod: string = core.getInput('traffic-split-method');

--- a/src/run.ts
+++ b/src/run.ts
@@ -59,7 +59,7 @@ export async function run() {
         namespace = 'default';
     }
     let action = core.getInput('action');
-    let manifests = manifestsInput.split(/[\n,]+/);
+    let manifests = manifestsInput.split(/[\n,]+/).filter(manifest => manifest.trim().length > 0);
 
     if (manifests.length > 0) {
         manifests = manifests.map(manifest => {

--- a/src/run.ts
+++ b/src/run.ts
@@ -59,7 +59,7 @@ export async function run() {
         namespace = 'default';
     }
     let action = core.getInput('action');
-    let manifests = manifestsInput.split('\n');
+    let manifests = manifestsInput.split(/[\n,]+/);
 
     if (action === 'deploy') {
         let strategy = core.getInput('strategy');

--- a/src/run.ts
+++ b/src/run.ts
@@ -61,6 +61,12 @@ export async function run() {
     let action = core.getInput('action');
     let manifests = manifestsInput.split(/[\n,]+/);
 
+    if (manifests.length > 0) {
+        manifests = manifests.map(manifest => {
+            return manifest.trim();
+        });
+    }
+
     if (action === 'deploy') {
         let strategy = core.getInput('strategy');
         console.log("strategy: ", strategy)

--- a/src/run.ts
+++ b/src/run.ts
@@ -59,7 +59,7 @@ export async function run() {
         namespace = 'default';
     }
     let action = core.getInput('action');
-    let manifests = manifestsInput.split(/[\n,]+/).filter(manifest => manifest.trim().length > 0);
+    let manifests = manifestsInput.split(/[\n,;]+/).filter(manifest => manifest.trim().length > 0);
 
     if (manifests.length > 0) {
         manifests = manifests.map(manifest => {


### PR DESCRIPTION
This PR adds support for providing input manifests separated by both commas and newline as delimiter.

The following formats should be supported post this change

```
manifests: |
    a.yml, b.yml, c.yml
```

```
manifests: |
    a.yml
    b.yml, c.yml
```

```
manifests: |
    a.yml
    b.yml
    c.yml
```

```
manifests: |
    a.yml;b.yml;c.yml
```
