### PR TITLE
fix kubectlPath value when setting kubectl-version

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -19,6 +19,8 @@ async function setKubectlPath() {
         kubectlPath = toolCache.find('kubectl', version);
         if (!kubectlPath) {
             kubectlPath = await installKubectl(version);
+        } else {
+            kubectlPath = path.join(kubectlPath, `kubectl${getExecutableExtension()}`);
         }
     } else {
         kubectlPath = await io.which('kubectl', false);


### PR DESCRIPTION
The path received from toolCache doesn't contain the tool name. This PR should put the same behavior on both section of code.

When using it with an already installed version of kubectl we have the following logs:

```
/home/debian/actions-runner/_work/_tool/kubectl/1.20.8/x64 apply -f /home/debian/actions-runner/_work/_temp/baked-template-1637851724167.yaml --namespace kube-system
``` 
note the abscence of `/kubectl` after `1.20.8/x64`. 

If we have already the version of `kubectl` downloaded on the runner, we set `kubectlPath` to the result of `toolCache.find`. This function by default return the path of the folder where the tool is located. See https://github.com/actions/toolkit/blob/2f164000dcd42fb08287824a3bc3030dbed33687/packages/tool-cache/src/tool-cache.ts#L489-L497 to see the incriminated code. 

We ran into this bug on an self-hosted GitHub Action runner. 

If `kubectl-version` is set, the variable `kubectlPath` is set to `path.join(_cacheDirectory(),"kubectl","v1.21.2","x64")` (for example, see https://github.com/actions/toolkit/blob/2f164000dcd42fb08287824a3bc3030dbed33687/packages/tool-cache/src/tool-cache.ts#L482-L487) and we expect it to add `kubectl` to this path as it's done a few line below: https://github.com/Azure/k8s-deploy/blob/33608d18f7cac6ef9e3a4b2831622ab560909e88/src/run.ts#L31 in the `else` code section.
