### PR TITLE
Making namespace annotation switchable

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ Following are the key capabilities of this action:
     <td>force </br></br>(Optional)</td>
     <td>Deploy when a previous deployment already exists. If true then '--force' argument is added to the apply command. Using '--force' argument is not recommended in production.</td>
   </tr>
+  <tr>
+    <td>annotate-namespace</br></br>(Optional)</td>
+    <td>Acceptable values: true/false</br>Default value: true</br>Switch whether to annotate the namespace resources object or not</td>
+  </tr>
 </table>
 
 ## Usage Examples

--- a/action.yml
+++ b/action.yml
@@ -51,6 +51,10 @@ inputs:
     description: "Github token"
     default: ${{ github.token }}
     required: true
+  annotate-namespace:
+    description: "Annotate the target namespace"
+    required: false
+    default: true
 
 branding:
   color: "green"

--- a/src/strategyHelpers/deploymentHelper.ts
+++ b/src/strategyHelpers/deploymentHelper.ts
@@ -173,9 +173,13 @@ async function annotateResources(
     workflowFilePath,
     deploymentConfig
   )}`;
-  annotateResults.push(
-    await kubectl.annotate("namespace", namespace, annotationKeyValStr)
-  );
+
+  const annotateNamespace = core.getInput("annotate-namespace").toLowerCase() === "true";
+  if (annotateNamespace) {
+    annotateResults.push(
+        await kubectl.annotate("namespace", namespace, annotationKeyValStr)
+    );
+  }
   annotateResults.push(await kubectl.annotateFiles(files, annotationKeyValStr));
 
   for (const resource of resourceTypes) {

--- a/src/strategyHelpers/deploymentHelper.ts
+++ b/src/strategyHelpers/deploymentHelper.ts
@@ -174,7 +174,7 @@ async function annotateResources(
     deploymentConfig
   )}`;
 
-  const annotateNamespace = core.getInput("annotate-namespace").toLowerCase() === "true";
+  const annotateNamespace = !(core.getInput("annotate-namespace").toLowerCase() === "false");
   if (annotateNamespace) {
     annotateResults.push(
         await kubectl.annotate("namespace", namespace, annotationKeyValStr)


### PR DESCRIPTION
In order to fix https://github.com/Azure/k8s-deploy/issues/149, I tried my very best to add a feature to make it possible switching off annotations to the namespace. 
The former behaviour of the action is considered to be the default, so behaviour only changes in case somebody explicitly sets the new input  parameter to `false`