### PR TITLE
Making pulling of images switchable

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ Following are the key capabilities of this action:
   <tr>
     <td>imagepullsecrets </br></br>(Optional)</td>
     <td>Multiline input where each line contains the name of a docker-registry secret that has already been setup within the cluster. Each of these secret names are added under imagePullSecrets field for the workloads found in the input manifest files</td>
+  </tr>  
+  <tr>
+    <td>pull-images</br></br>(Optional)</td>
+    <td>Acceptable values: true/false</br>Default value: true</br>Switch whether to pull the images from the registry before deployment to find out Dockerfile's path in order to add it to the annotations</td>
   </tr>
   <tr>
     <td>strategy </br></br>(Optional)</td>

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,10 @@ inputs:
   imagepullsecrets:
     description: "Name of a docker-registry secret that has already been set up within the cluster. Each of these secret names are added under imagePullSecrets field for the workloads found in the input manifest files"
     required: false
+  pull-images:
+    description: "Switch whether to pull the images from the registry before deployment to find out Dockerfile's path in order to add it to the annotations"
+    required: false
+    default: true
   strategy:
     description: "Deployment strategy to be used. Allowed values are none, canary and blue-green"
     required: false

--- a/src/utilities/dockerUtils.ts
+++ b/src/utilities/dockerUtils.ts
@@ -26,7 +26,7 @@ export async function getDeploymentConfig(): Promise<DeploymentConfig> {
   const imageNames = core.getInput("images").split("\n") || [];
   const imageDockerfilePathMap: { [id: string]: string } = {};
 
-  const pullImages = core.getInput("pull-images").toLowerCase() === "true";
+  const pullImages = !(core.getInput("pull-images").toLowerCase() === "false");
   if (pullImages) {
     //Fetching from image label if available
     for (const image of imageNames) {

--- a/src/utilities/dockerUtils.ts
+++ b/src/utilities/dockerUtils.ts
@@ -26,14 +26,17 @@ export async function getDeploymentConfig(): Promise<DeploymentConfig> {
   const imageNames = core.getInput("images").split("\n") || [];
   const imageDockerfilePathMap: { [id: string]: string } = {};
 
-  //Fetching from image label if available
-  for (const image of imageNames) {
-    try {
-      imageDockerfilePathMap[image] = await getDockerfilePath(image);
-    } catch (ex) {
-      core.warning(
-        `Failed to get dockerfile path for image ${image.toString()}: ${ex} `
-      );
+  const pullImages = core.getInput("pull-images").toLowerCase() === "true";
+  if (pullImages) {
+    //Fetching from image label if available
+    for (const image of imageNames) {
+      try {
+        imageDockerfilePathMap[image] = await getDockerfilePath(image);
+      } catch (ex) {
+        core.warning(
+            `Failed to get dockerfile path for image ${image.toString()}: ${ex} `
+        );
+      }
     }
   }
 


### PR DESCRIPTION
The avoid warnings during deployment process, this PR makes the pulling of images to find out Dockerfile's path switchable off.

Cases where there was the warning in former releases: 

- Action executes on self-hosted runners without Docker installed or other containerization technology installed (e.g. Podman)
- Workflow doesn't have access to the registry of the images