### PR TITLE
Route API requests to GHES if it's used

### DIFF
--- a/src/types/githubClient.ts
+++ b/src/types/githubClient.ts
@@ -24,6 +24,7 @@ export class GitHubClient {
     const octokit = new RetryOctokit({
       auth: this.token,
       request: { retries: RETRY_COUNT },
+      baseUrl: process.env["GITHUB_API_URL"] || "https://api.github.com",
     });
     const [owner, repo] = this.repository.split("/");
 


### PR DESCRIPTION
Octokit/core sends by default stuff to github.com api. It of course fails when user is using github enterprise server, as token created by GHES is sent to .com that doesn't recognize it, resulting in `Bad credentials` error.

We can use [env var](https://docs.github.com/en/enterprise-server@2.22/actions/learn-github-actions/environment-variables) defined by github runner itself to know the correct domain requests have to be sent to.

Fix #190 