### PR TITLE
consider slashes while cleaning labels

### DIFF
--- a/src/utilities/workflowAnnotationUtils.test.ts
+++ b/src/utilities/workflowAnnotationUtils.test.ts
@@ -11,5 +11,10 @@ describe('WorkflowAnnotationUtils', () => {
          )
          expect(cleanLabel('with⚒️emoji')).toEqual('withemoji')
       })
+      it('should remove slashes from label', () => {
+         expect(
+            cleanLabel('Workflow Name / With Slashes / And Spaces')
+         ).toEqual('Workflow_Name_-_With_Slashes_-_And_Spaces')
+      })
    })
 })

--- a/src/utilities/workflowAnnotationUtils.ts
+++ b/src/utilities/workflowAnnotationUtils.ts
@@ -37,7 +37,11 @@ export function getWorkflowAnnotationKeyLabel(): string {
  * @returns cleaned label
  */
 export function cleanLabel(label: string): string {
-   const removedInvalidChars = label.replace(/[^-A-Za-z0-9_.]/gi, '')
+   let removedInvalidChars = label
+      .replace(/\s/gi, '_')
+      .replace(/[\/\\\|]/gi, '-')
+      .replace(/[^-A-Za-z0-9_.]/gi, '')
+
    const regex = /([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]/
    return regex.exec(removedInvalidChars)[0] || ''
 }


### PR DESCRIPTION
I was running into this kind of error, while trying to deploy to my k8s cluster. 
```
error: invalid label value: "workflowFriendlyName=Develop_/_Deploy_To_k8s_Cluster": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')
```
In addition to https://github.com/Azure/k8s-deploy/pull/211 which does not remove slashes, I replaced slashes with dashes. This fixes #105 again which is already merged and fixed, but the implementation misses consideration of slashes, as mentioned here https://github.com/Azure/k8s-deploy/issues/105#issuecomment-1127785348  

What I did in this PR: In the `cleanLabel` method, I 
- replace whitespaces ` ` with underscore `_`
- replace slashes, pipes and backslashes `\ | /` with dash `-`
- remove invalid characters