### PR TITLE
Fix issue form syntax errors

### DIFF
--- a/.github/ISSUE_TEMPLATE/bugReportForm.yml
+++ b/.github/ISSUE_TEMPLATE/bugReportForm.yml
@@ -4,7 +4,7 @@ title: 'Bug: '
 labels: ['bug', 'triage']
 assignees: '@Azure/aks-atlanta'
 body:
-   - type: input
+   - type: textarea
      id: What-happened
      attributes:
         label: What happened?
@@ -27,11 +27,10 @@ body:
         placeholder: Mention the runner info (self-hosted, operating system)
      validations:
         required: true
-   - type: input
+   - type: textarea
      id: Logs
      attributes:
         label: Relevant log output
         description: Run in debug mode for the most verbose logs. Please feel free to attach a screenshot of the logs
-        render: shell
      validations:
         required: true

--- a/.github/ISSUE_TEMPLATE/featureRequestForm.yml
+++ b/.github/ISSUE_TEMPLATE/featureRequestForm.yml
@@ -4,8 +4,8 @@ title: 'Feature Request: '
 labels: ['Feature']
 assignees: '@Azure/aks-atlanta'
 body:
-   - type: input
-     id: Feature request
+   - type: textarea
+     id: Feature_request
      attributes:
         label: Feature request
         description: Provide example functionality and links to relevant docs


### PR DESCRIPTION
Hi 👋 . I just wanted to open a new issue (bug report), but the form seems not displayed due to syntax errors.

## Problem
Only the repository link defined in `config.yml` are displayed. The other files (`bugReportForm.yml` and `featureRequestForm.yml`) are not displayed due to the format error.

<img width="600" alt="issue_form_01" src="https://user-images.githubusercontent.com/1172471/189480090-b942dfbf-0c50-4d08-aeac-f91a1cc8aa5c.png">
<img width="400" alt="issue_form_02" src="https://user-images.githubusercontent.com/1172471/189480096-5eb31d44-2ff3-4bb7-881c-fe6767da166a.png">
<img width="400" alt="issue_form_03" src="https://user-images.githubusercontent.com/1172471/189480102-2255ce78-1937-4105-87a8-de162366641e.png">

## Changes
- Fix syntax errors in issue-forms for displaying them as candidates.
- Apply `textarea` for description fields instead of `input` (for allowing longer and multi-line text).