### PR TITLE
Check for error from Azure when using the private-cluster feature

### DIFF
--- a/src/types/privatekubectl.test.ts
+++ b/src/types/privatekubectl.test.ts
@@ -1,12 +1,32 @@
 import {PrivateKubectl} from './privatekubectl'
+import * as exec from '@actions/exec'
 
 describe('Private kubectl', () => {
    const testString = `kubectl annotate -f test.yml,test2.yml,test3.yml -f test4.yml --filename test5.yml actions.github.com/k8s-deploy={"run":"3498366832","repository":"jaiveerk/k8s-deploy","workflow":"Minikube Integration Tests - private cluster","workflowFileName":"run-integration-tests-private.yml","jobName":"run-integration-test","createdBy":"jaiveerk","runUri":"https://github.com/jaiveerk/k8s-deploy/actions/runs/3498366832","commit":"c63b323186ea1320a31290de6dcc094c06385e75","lastSuccessRunCommit":"NA","branch":"refs/heads/main","deployTimestamp":1668787848577,"dockerfilePaths":{"nginx:1.14.2":""},"manifestsPaths":["https://github.com/jaiveerk/k8s-deploy/blob/c63b323186ea1320a31290de6dcc094c06385e75/test/integration/manifests/test.yml"],"helmChartPaths":[],"provider":"GitHub"} --overwrite --namespace test-3498366832`
-   const mockKube = new PrivateKubectl('')
+   const mockKube = new PrivateKubectl(
+      'kubectlPath',
+      'namespace',
+      true,
+      'resourceGroup',
+      'resourceName'
+   )
 
    it('should extract filenames correctly', () => {
       expect(mockKube.extractFilesnames(testString)).toEqual(
          'test.yml test2.yml test3.yml test4.yml test5.yml'
+      )
+   })
+
+   test('Should throw well defined Error on error from Azure', async () => {
+      const errorMsg = 'An error message'
+      jest.spyOn(exec, 'getExecOutput').mockImplementation(async () => {
+         return {exitCode: 1, stdout: '', stderr: errorMsg}
+      })
+
+      await expect(mockKube.executeCommand('az', 'test')).rejects.toThrow(
+         Error(
+            `Call to private cluster failed. Command: 'kubectl az test --insecure-skip-tls-verify --namespace namespace', errormessage: ${errorMsg}`
+         )
       )
    })
 })

--- a/src/types/privatekubectl.ts
+++ b/src/types/privatekubectl.ts
@@ -75,13 +75,17 @@ export class PrivateKubectl extends Kubectl {
             runOutput
          )}`
       )
+
+      if (runOutput.exitCode !== 0) {
+         throw Error(
+            `Call to private cluster failed. Command: '${kubectlCmd}', errormessage: ${runOutput.stderr}`
+         )
+      }
+
       const runObj: {logs: string; exitCode: number} = JSON.parse(
          runOutput.stdout
       )
       if (!silent) core.info(runObj.logs)
-      if (runOutput.exitCode !== 0 && runObj.exitCode !== 0) {
-         throw Error(`failed private cluster Kubectl command: ${kubectlCmd}`)
-      }
 
       return {
          exitCode: runObj.exitCode,

--- a/src/types/privatekubectl.ts
+++ b/src/types/privatekubectl.ts
@@ -86,6 +86,9 @@ export class PrivateKubectl extends Kubectl {
          runOutput.stdout
       )
       if (!silent) core.info(runObj.logs)
+      if (runObj.exitCode !== 0) {
+         throw Error(`failed private cluster Kubectl command: ${kubectlCmd}`)
+      }
 
       return {
          exitCode: runObj.exitCode,


### PR DESCRIPTION
Move the error check for Azure earlier, so that a well defined error is thrown on error instead of a JSONSyntax error.

The issue is that when Azure returns an error, like when there's an issue with the access to the principal used. When this happens, the stdout field will be an empty string, and the error message will be set to a non-json string.