### PR TITLE
abstract methods to avoid drift

### DIFF
--- a/src/utilities/workflowAnnotationUtils.test.ts
+++ b/src/utilities/workflowAnnotationUtils.test.ts
@@ -1,4 +1,8 @@
-import {cleanLabel} from '../utilities/workflowAnnotationUtils'
+import {
+   cleanLabel,
+   removeInvalidLabelCharacters,
+   VALID_LABEL_REGEX
+} from '../utilities/workflowAnnotationUtils'
 
 describe('WorkflowAnnotationUtils', () => {
    describe('cleanLabel', () => {
@@ -20,13 +24,9 @@ describe('WorkflowAnnotationUtils', () => {
          const label = '持续部署'
          expect(cleanLabel(label)).toEqual('github-workflow-file')
 
-         let removedInvalidChars = label
-            .replace(/\s/gi, '_')
-            .replace(/[\/\\\|]/gi, '-')
-            .replace(/[^-A-Za-z0-9_.]/gi, '')
+         let removedInvalidChars = removeInvalidLabelCharacters(label)
 
-         const regex = /([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]/
-         const regexResult = regex.exec(removedInvalidChars)
+         const regexResult = VALID_LABEL_REGEX.exec(removedInvalidChars)
          expect(regexResult).toBe(null)
       })
    })

--- a/src/utilities/workflowAnnotationUtils.ts
+++ b/src/utilities/workflowAnnotationUtils.ts
@@ -2,6 +2,8 @@ import {DeploymentConfig} from '../types/deploymentConfig'
 
 const ANNOTATION_PREFIX = 'actions.github.com'
 
+export const VALID_LABEL_REGEX = /([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]/
+
 export function getWorkflowAnnotations(
    lastSuccessRunSha: string,
    workflowFilePath: string,
@@ -37,14 +39,17 @@ export function getWorkflowAnnotationKeyLabel(): string {
  * @returns cleaned label
  */
 export function cleanLabel(label: string): string {
-   let removedInvalidChars = label
-      .replace(/\s/gi, '_')
-      .replace(/[\/\\\|]/gi, '-')
-      .replace(/[^-A-Za-z0-9_.]/gi, '')
+   let removedInvalidChars = removeInvalidLabelCharacters(label)
 
-   const regex = /([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]/
-   const regexResult = regex.exec(removedInvalidChars) || [
+   const regexResult = VALID_LABEL_REGEX.exec(removedInvalidChars) || [
       'github-workflow-file'
    ]
    return regexResult[0]
+}
+
+export function removeInvalidLabelCharacters(label: string): string {
+   return label
+      .replace(/\s/gi, '_')
+      .replace(/[\/\\\|]/gi, '-')
+      .replace(/[^-A-Za-z0-9_.]/gi, '')
 }


### PR DESCRIPTION
- abstract a couple methods in the label cleaning to avoid drift
- avoid having regexes in the tests themselves