### PR TITLE
upgrade codeql

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,11 +19,6 @@ jobs:
               # a pull request then we can checkout the head.
               fetch-depth: 2
 
-         # If this run was triggered by a pull request event, then checkout
-         # the head of the pull request instead of the merge commit.
-         - run: git checkout HEAD^2
-           if: ${{ github.event_name == 'pull_request' }}
-
          # Initializes the CodeQL tools for scanning.
          - name: Initialize CodeQL
            uses: github/codeql-action/init@v1
@@ -34,7 +29,7 @@ jobs:
          # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
          # If this step fails, then you should remove it and run the build manually (see below)
          - name: Autobuild
-           uses: github/codeql-action/autobuild@v1
+           uses: github/codeql-action/autobuild@v2
 
          # ℹ️ Command-line programs to run using the OS shell.
          # 📚 https://git.io/JvXDl
@@ -48,4 +43,4 @@ jobs:
          #   make release
 
          - name: Perform CodeQL Analysis
-           uses: github/codeql-action/analyze@v1
+           uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
codeql v1 is deprecated, so we need to upgrade to allow the check to pass and unblock PRs

https://github.blog/changelog/2022-04-27-code-scanning-deprecation-of-codeql-action-v1/

updated to removed the checkout HEAD^2 as this is no longer recommended in the docs
![image](https://user-images.githubusercontent.com/4248857/215887811-87377ef1-4e03-4fae-8f30-f354d943ae40.png)

https://github.com/Azure/k8s-deploy/actions/runs/3870184983/jobs/6596900421#step:4:9