### PR TITLE
Fix “Service” route-method of the Blue-Green strategy with some manifest files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,8 +22,8 @@
             "@types/jest": "^26.0.0",
             "@types/js-yaml": "^3.12.7",
             "@types/node": "^12.20.41",
+            "@vercel/ncc": "^0.36.1",
             "jest": "^26.0.0",
-            "ncc": "^0.3.6",
             "prettier": "^2.7.1",
             "ts-jest": "^26.0.0",
             "typescript": "3.9.5"
@@ -1183,6 +1183,15 @@
          "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
          "dev": true
       },
+      "node_modules/@vercel/ncc": {
+         "version": "0.36.1",
+         "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.36.1.tgz",
+         "integrity": "sha512-S4cL7Taa9yb5qbv+6wLgiKVZ03Qfkc4jGRuiUQMQ8HGBD5pcNRnHeYM33zBvJE4/zJGjJJ8GScB+WmTsn9mORw==",
+         "dev": true,
+         "bin": {
+            "ncc": "dist/ncc/cli.js"
+         }
+      },
       "node_modules/abab": {
          "version": "2.0.6",
          "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
@@ -1875,15 +1884,6 @@
          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
          "dev": true
       },
-      "node_modules/colors": {
-         "version": "1.2.3",
-         "resolved": "https://registry.npmjs.org/colors/-/colors-1.2.3.tgz",
-         "integrity": "sha512-qTfM2pNFeMZcLvf/RbrVAzDEVttZjFhaApfx9dplNjvHSX88Ui66zBRb/4YGob/xUWxDceirgoC1lT676asfCQ==",
-         "dev": true,
-         "engines": {
-            "node": ">=0.1.90"
-         }
-      },
       "node_modules/combined-stream": {
          "version": "1.0.8",
          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -1976,15 +1976,6 @@
          },
          "engines": {
             "node": ">=10"
-         }
-      },
-      "node_modules/dateformat": {
-         "version": "3.0.3",
-         "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
-         "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
-         "dev": true,
-         "engines": {
-            "node": "*"
          }
       },
       "node_modules/debug": {
@@ -4091,58 +4082,6 @@
          "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
          "dev": true
       },
-      "node_modules/ncc": {
-         "version": "0.3.6",
-         "resolved": "https://registry.npmjs.org/ncc/-/ncc-0.3.6.tgz",
-         "integrity": "sha512-OXudTB2Ebt/FnOuDoPQbaa17+tdVqSOWA+gLfPxccWwsNED1uA2zEhpoB1hwdFC9yYbio/mdV5cvOtQI3Zrx1w==",
-         "dev": true,
-         "dependencies": {
-            "mkdirp": "^0.5.1",
-            "rimraf": "^2.6.1",
-            "tracer": "^0.8.7",
-            "ws": "^2.3.1"
-         }
-      },
-      "node_modules/ncc/node_modules/mkdirp": {
-         "version": "0.5.6",
-         "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-         "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-         "dev": true,
-         "dependencies": {
-            "minimist": "^1.2.6"
-         },
-         "bin": {
-            "mkdirp": "bin/cmd.js"
-         }
-      },
-      "node_modules/ncc/node_modules/rimraf": {
-         "version": "2.7.1",
-         "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-         "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-         "dev": true,
-         "dependencies": {
-            "glob": "^7.1.3"
-         },
-         "bin": {
-            "rimraf": "bin.js"
-         }
-      },
-      "node_modules/ncc/node_modules/safe-buffer": {
-         "version": "5.0.1",
-         "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-         "integrity": "sha512-cr7dZWLwOeaFBLTIuZeYdkfO7UzGIKhjYENJFAxUOMKWGaWDm2nJM2rzxNRm5Owu0DH3ApwNo6kx5idXZfb/Iw==",
-         "dev": true
-      },
-      "node_modules/ncc/node_modules/ws": {
-         "version": "2.3.1",
-         "resolved": "https://registry.npmjs.org/ws/-/ws-2.3.1.tgz",
-         "integrity": "sha512-61a+9LgtYZxTq1hAonhX8Xwpo2riK4IOR/BIVxioFbCfc3QFKmpE4x9dLExfLHKtUfVZigYa36tThVhO57erEw==",
-         "dev": true,
-         "dependencies": {
-            "safe-buffer": "~5.0.1",
-            "ultron": "~1.1.0"
-         }
-      },
       "node_modules/nice-try": {
          "version": "1.0.5",
          "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -5883,15 +5822,6 @@
          "integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
          "dev": true
       },
-      "node_modules/tinytim": {
-         "version": "0.1.1",
-         "resolved": "https://registry.npmjs.org/tinytim/-/tinytim-0.1.1.tgz",
-         "integrity": "sha512-NIpsp9lBIxPNzB++HnMmUd4byzJSVbbO4F+As1Gb1IG/YQT5QvmBDjpx8SpDS8fhGC+t+Qw8ldQgbcAIaU+2cA==",
-         "dev": true,
-         "engines": {
-            "node": ">= 0.2.0"
-         }
-      },
       "node_modules/tmpl": {
          "version": "1.0.5",
          "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -5982,33 +5912,6 @@
          },
          "engines": {
             "node": ">=8"
-         }
-      },
-      "node_modules/tracer": {
-         "version": "0.8.15",
-         "resolved": "https://registry.npmjs.org/tracer/-/tracer-0.8.15.tgz",
-         "integrity": "sha512-ZQzlhd6zZFIpAhACiZkxLjl65XqVwi8t8UEBVGRIHAQN6nj55ftJWiFell+WSqWCP/vEycrIbUSuiyMwul+TFw==",
-         "dev": true,
-         "dependencies": {
-            "colors": "1.2.3",
-            "dateformat": "3.0.3",
-            "mkdirp": "^0.5.1",
-            "tinytim": "0.1.1"
-         },
-         "engines": {
-            "node": ">= 0.10.0"
-         }
-      },
-      "node_modules/tracer/node_modules/mkdirp": {
-         "version": "0.5.6",
-         "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-         "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-         "dev": true,
-         "dependencies": {
-            "minimist": "^1.2.6"
-         },
-         "bin": {
-            "mkdirp": "bin/cmd.js"
          }
       },
       "node_modules/ts-jest": {
@@ -6126,12 +6029,6 @@
          "engines": {
             "node": ">=4.2.0"
          }
-      },
-      "node_modules/ultron": {
-         "version": "1.1.1",
-         "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
-         "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
-         "dev": true
       },
       "node_modules/underscore": {
          "version": "1.13.4",
@@ -7493,6 +7390,12 @@
          "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
          "dev": true
       },
+      "@vercel/ncc": {
+         "version": "0.36.1",
+         "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.36.1.tgz",
+         "integrity": "sha512-S4cL7Taa9yb5qbv+6wLgiKVZ03Qfkc4jGRuiUQMQ8HGBD5pcNRnHeYM33zBvJE4/zJGjJJ8GScB+WmTsn9mORw==",
+         "dev": true
+      },
       "abab": {
          "version": "2.0.6",
          "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
@@ -8020,12 +7923,6 @@
          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
          "dev": true
       },
-      "colors": {
-         "version": "1.2.3",
-         "resolved": "https://registry.npmjs.org/colors/-/colors-1.2.3.tgz",
-         "integrity": "sha512-qTfM2pNFeMZcLvf/RbrVAzDEVttZjFhaApfx9dplNjvHSX88Ui66zBRb/4YGob/xUWxDceirgoC1lT676asfCQ==",
-         "dev": true
-      },
       "combined-stream": {
          "version": "1.0.8",
          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -8106,12 +8003,6 @@
             "whatwg-mimetype": "^2.3.0",
             "whatwg-url": "^8.0.0"
          }
-      },
-      "dateformat": {
-         "version": "3.0.3",
-         "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
-         "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
-         "dev": true
       },
       "debug": {
          "version": "4.3.4",
@@ -9728,54 +9619,6 @@
          "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
          "dev": true
       },
-      "ncc": {
-         "version": "0.3.6",
-         "resolved": "https://registry.npmjs.org/ncc/-/ncc-0.3.6.tgz",
-         "integrity": "sha512-OXudTB2Ebt/FnOuDoPQbaa17+tdVqSOWA+gLfPxccWwsNED1uA2zEhpoB1hwdFC9yYbio/mdV5cvOtQI3Zrx1w==",
-         "dev": true,
-         "requires": {
-            "mkdirp": "^0.5.1",
-            "rimraf": "^2.6.1",
-            "tracer": "^0.8.7",
-            "ws": "^2.3.1"
-         },
-         "dependencies": {
-            "mkdirp": {
-               "version": "0.5.6",
-               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-               "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-               "dev": true,
-               "requires": {
-                  "minimist": "^1.2.6"
-               }
-            },
-            "rimraf": {
-               "version": "2.7.1",
-               "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-               "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-               "dev": true,
-               "requires": {
-                  "glob": "^7.1.3"
-               }
-            },
-            "safe-buffer": {
-               "version": "5.0.1",
-               "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-               "integrity": "sha512-cr7dZWLwOeaFBLTIuZeYdkfO7UzGIKhjYENJFAxUOMKWGaWDm2nJM2rzxNRm5Owu0DH3ApwNo6kx5idXZfb/Iw==",
-               "dev": true
-            },
-            "ws": {
-               "version": "2.3.1",
-               "resolved": "https://registry.npmjs.org/ws/-/ws-2.3.1.tgz",
-               "integrity": "sha512-61a+9LgtYZxTq1hAonhX8Xwpo2riK4IOR/BIVxioFbCfc3QFKmpE4x9dLExfLHKtUfVZigYa36tThVhO57erEw==",
-               "dev": true,
-               "requires": {
-                  "safe-buffer": "~5.0.1",
-                  "ultron": "~1.1.0"
-               }
-            }
-         }
-      },
       "nice-try": {
          "version": "1.0.5",
          "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -11139,12 +10982,6 @@
          "integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
          "dev": true
       },
-      "tinytim": {
-         "version": "0.1.1",
-         "resolved": "https://registry.npmjs.org/tinytim/-/tinytim-0.1.1.tgz",
-         "integrity": "sha512-NIpsp9lBIxPNzB++HnMmUd4byzJSVbbO4F+As1Gb1IG/YQT5QvmBDjpx8SpDS8fhGC+t+Qw8ldQgbcAIaU+2cA==",
-         "dev": true
-      },
       "tmpl": {
          "version": "1.0.5",
          "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -11216,29 +11053,6 @@
          "dev": true,
          "requires": {
             "punycode": "^2.1.1"
-         }
-      },
-      "tracer": {
-         "version": "0.8.15",
-         "resolved": "https://registry.npmjs.org/tracer/-/tracer-0.8.15.tgz",
-         "integrity": "sha512-ZQzlhd6zZFIpAhACiZkxLjl65XqVwi8t8UEBVGRIHAQN6nj55ftJWiFell+WSqWCP/vEycrIbUSuiyMwul+TFw==",
-         "dev": true,
-         "requires": {
-            "colors": "1.2.3",
-            "dateformat": "3.0.3",
-            "mkdirp": "^0.5.1",
-            "tinytim": "0.1.1"
-         },
-         "dependencies": {
-            "mkdirp": {
-               "version": "0.5.6",
-               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-               "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-               "dev": true,
-               "requires": {
-                  "minimist": "^1.2.6"
-               }
-            }
          }
       },
       "ts-jest": {
@@ -11319,12 +11133,6 @@
          "version": "3.9.5",
          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.5.tgz",
          "integrity": "sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==",
-         "dev": true
-      },
-      "ultron": {
-         "version": "1.1.1",
-         "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
-         "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
          "dev": true
       },
       "underscore": {

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
       "@types/jest": "^26.0.0",
       "@types/js-yaml": "^3.12.7",
       "@types/node": "^12.20.41",
+      "@vercel/ncc": "^0.36.1",
       "jest": "^26.0.0",
-      "ncc": "^0.3.6",
       "prettier": "^2.7.1",
       "ts-jest": "^26.0.0",
       "typescript": "3.9.5"


### PR DESCRIPTION
With the current implementation of the “Service” route-method of the Blue-Green strategy, if the manifest file contains `Service` object _before_ `Deployment` ones, then, `Service` isn’t updated with the right labels selector.

<details><summary>Sample affected manifest file</summary>

```yaml
apiVersion: v1
kind: Service
metadata:
   name: nginx-service
spec:
   selector:
      app: nginx
   ports:
      - protocol: TCP
        port: 80
        targetPort: 80
---
apiVersion: apps/v1
kind: Deployment
metadata:
   name: nginx-deployment
   labels:
      app: nginx
spec:
   replicas: 1
   selector:
      matchLabels:
         app: nginx
   template:
      metadata:
         labels:
            app: nginx
      spec:
         containers:
            - name: nginx
              image: nginx
              ports:
                 - containerPort: 80
```
</details>

To fix this issue, update `getManifestObjects()` function in the `src/strategyHelpers/blueGreen/blueGreenHelper.ts` file to first extract all objects from the manifest file, and _then_ identify “routed” service entities. This way, even if the `Deployment` object is declared after the “routed” `Service`, Blue-Green strategy will be able to _not_ update the `Service` until the routing switch (done in `routeBlueGreenForDeploy()`, in `src/strategyHelpers/blueGreen/route.ts`).