### PR TITLE
Make annotating resources optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,10 @@ Following are the key capabilities of this action:
     <td>Deploy when a previous deployment already exists. If true then '--force' argument is added to the apply command. Using '--force' argument is not recommended in production.</td>
   </tr>
   <tr>
+    <td>annotate-resources</br></br>(Optional)</td>
+    <td>Acceptable values: true/false</br>Default value: true</br>Switch whether to annotate all the resources or not</td>
+  </tr>
+  <tr>
     <td>annotate-namespace</br></br>(Optional)</td>
     <td>Acceptable values: true/false</br>Default value: true</br>Switch whether to annotate the namespace resources object or not</td>
   </tr>

--- a/action.yml
+++ b/action.yml
@@ -59,6 +59,10 @@ inputs:
       description: 'Github token'
       default: ${{ github.token }}
       required: true
+   annotate-resources:
+      description: 'Annotate all the resources'
+      required: false
+      default: true
    annotate-namespace:
       description: 'Annotate the target namespace'
       required: false

--- a/src/actions/deploy.ts
+++ b/src/actions/deploy.ts
@@ -64,18 +64,24 @@ export async function deploy(
    core.endGroup()
 
    // annotate resources
-   core.startGroup('Annotating resources')
-   let allPods
-   try {
-      allPods = JSON.parse((await kubectl.getAllPods()).stdout)
-   } catch (e) {
-      core.debug(`Unable to parse pods: ${e}`)
-   }
-   await annotateAndLabelResources(
-      deployedManifestFiles,
-      kubectl,
-      resourceTypes,
-      allPods
+   const annotateResources = !(
+       core.getInput('annotate-resources').toLowerCase() === 'false'
    )
-   core.endGroup()
+   if (annotateResources) {
+      core.startGroup('Annotating resources')
+      let allPods
+      try {
+         allPods = JSON.parse((await kubectl.getAllPods()).stdout)
+      } catch (e) {
+         core.debug(`Unable to parse pods: ${e}`)
+      }
+      await annotateAndLabelResources(
+          deployedManifestFiles,
+          kubectl,
+          resourceTypes,
+          allPods
+      )
+      core.endGroup()
+   }
+
 }


### PR DESCRIPTION
We would like to run the deployment action without annotating the resources afterwards so I made an change to pass this as an optional parameter.