### PR TITLE
bump minikube to fix runner deps

### DIFF
--- a/.github/workflows/run-integration-tests-bluegreen-ingress.yml
+++ b/.github/workflows/run-integration-tests-bluegreen-ingress.yml
@@ -38,7 +38,7 @@ jobs:
            name: Setup Minikube
            uses: medyagh/setup-minikube@latest
            with:
-              minikube-version: 1.24.0
+              minikube-version: 1.31.2
               kubernetes-version: 1.22.3
               driver: 'none'
            timeout-minutes: 3

--- a/.github/workflows/run-integration-tests-bluegreen-service.yml
+++ b/.github/workflows/run-integration-tests-bluegreen-service.yml
@@ -38,7 +38,7 @@ jobs:
            name: Setup Minikube
            uses: medyagh/setup-minikube@latest
            with:
-              minikube-version: 1.24.0
+              minikube-version: 1.31.2
               kubernetes-version: 1.22.3
               driver: 'none'
            timeout-minutes: 3


### PR DESCRIPTION
currently PRs can't merge because the minikube version isn't working with the new ubuntu tag