### PR TITLE
bump release workflow sha

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -10,6 +10,6 @@ on:
 
 jobs:
    release:
-      uses: Azure/action-release-workflows/.github/workflows/release_js_project.yaml@12e20b8
+      uses: Azure/action-release-workflows/.github/workflows/release_js_project.yaml@12e20b89e7822d372714b84a7a844ba88fb1bbf0
       with:
          changelogPath: ./CHANGELOG.md


### PR DESCRIPTION
the current workflow uses a short hash which apparently isn't supported