### PR TITLE
add release worklflow artifact fix

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -10,6 +10,6 @@ on:
 
 jobs:
    release:
-      uses: Azure/action-release-workflows/.github/workflows/release_js_project.yaml@12e20b89e7822d372714b84a7a844ba88fb1bbf0
+      uses: Azure/action-release-workflows/.github/workflows/release_js_project.yaml@81e6a8ed41ced9d131dea884ecae7b8c6dc4f799
       with:
          changelogPath: ./CHANGELOG.md


### PR DESCRIPTION
bump the commit hash for our release workflow to include fixes to the release process including patching .gitignore to include missing lib directory on release branches