### PR TITLE
add installing ncc to build

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
    "author": "Deepak Sattiraju",
    "license": "MIT",
    "scripts": {
-      "build": "npx ncc build src/run.ts -o lib",
+      "build": "npm i ncc && ncc build src/run.ts -o lib",
       "test": "jest",
       "coverage": "jest --coverage=true",
       "format": "prettier --write .",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
    "author": "Deepak Sattiraju",
    "license": "MIT",
    "scripts": {
-      "build": "npm i ncc && ncc build src/run.ts -o lib",
+      "build": "npm i ncc && npx ncc build src/run.ts -o lib",
       "test": "jest",
       "coverage": "jest --coverage=true",
       "format": "prettier --write .",


### PR DESCRIPTION
use a local bin link just for ncc to get a bin link prior to calling with npx, as it isn't working correctly on our action runners

using just `npx ncc` isn't working since the install/build step doesn't add bin links, and we have to manually add one for ncc which we use for building

link to a working version on my fork https://github.com/davidgamero/k8s-deploy/actions/runs/6751019098/job/18354429862