### PR TITLE
fix: ensure imageNames are not empty strings

### DIFF
--- a/src/utilities/dockerUtils.ts
+++ b/src/utilities/dockerUtils.ts
@@ -23,7 +23,11 @@ export async function getDeploymentConfig(): Promise<DeploymentConfig> {
       )
    }
 
-   const imageNames = core.getInput('images').split('\n') || []
+   const imageNames =
+      core
+         .getInput('images')
+         .split('\n')
+         .filter((image) => image.length > 0) || []
    const imageDockerfilePathMap: {[id: string]: string} = {}
 
    const pullImages = !(core.getInput('pull-images').toLowerCase() === 'false')


### PR DESCRIPTION
In Typescript/Javascript an empty string split on newline is going to produce an array with an empty string.

    => "".split('\n')
    [""]

This causes the action to produce a warning, unless `pull-images` is set to false.

    Failed to get dockerfile path for image : Error: The process '/usr/bin/docker' failed with exit code 1

Filtering the list to remove any zero-length strings from the array solves this issue.