### PR TITLE
node.js20 update

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -84,5 +84,5 @@ inputs:
 branding:
    color: 'green'
 runs:
-   using: 'node16'
+   using: 'node20'
    main: 'lib/index.js'


### PR DESCRIPTION
Fix warning like: Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: