### PR TITLE
Make namespace input optional

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,9 +4,8 @@ inputs:
    # Please ensure you have used either azure/k8s-actions/aks-set-context or azure/k8s-actions/k8s-set-context in the workflow before this action
    # You also need to have kubectl installed (azure/setup-kubectl)
    namespace:
-      description: 'Choose the target Kubernetes namespace. If the namespace is not provided, the commands will run in the default namespace.'
+      description: 'Namespace to be added to all kubectl commands.'
       required: false
-      default: default
    manifests:
       description: 'Path to the manifest files which will be used for deployment.'
       required: true
@@ -64,7 +63,7 @@ inputs:
       required: false
       default: true
    annotate-namespace:
-      description: 'Annotate the target namespace. Ignored when annotate-resources is set to false.'
+      description: 'Annotate the target namespace. Ignored when annotate-resources is set to false or no namespace is provided'
       required: false
       default: true
    private-cluster:

--- a/src/run.ts
+++ b/src/run.ts
@@ -30,7 +30,7 @@ export async function run() {
       manifestFilePaths
    )
    const kubectlPath = await getKubectlPath()
-   const namespace = core.getInput('namespace') || 'default'
+   const namespace = core.getInput('namespace') || ''
    const isPrivateCluster =
       core.getInput('private-cluster').toLowerCase() === 'true'
    const resourceGroup = core.getInput('resource-group') || ''

--- a/src/strategyHelpers/deploymentHelper.ts
+++ b/src/strategyHelpers/deploymentHelper.ts
@@ -191,7 +191,7 @@ async function annotateResources(
    deploymentConfig: DeploymentConfig
 ) {
    const annotateResults: ExecOutput[] = []
-   const namespace = core.getInput('namespace') || 'default'
+   const namespace = core.getInput('namespace') || ''
    const lastSuccessSha = await getLastSuccessfulRunSha(
       kubectl,
       namespace,
@@ -217,7 +217,7 @@ async function annotateResources(
    )}`
 
    const annotateNamespace = !(
-      core.getInput('annotate-namespace').toLowerCase() === 'false'
+      namespace === '' || core.getInput('annotate-namespace').toLowerCase() === 'false'
    )
    if (annotateNamespace) {
       annotateResults.push(


### PR DESCRIPTION
This allows to deploy manifests in multiple different namespaces. `annotate-namespace` cannot be used if no namespace is given.