### PR TITLE
pin ubuntu 22.04, upgrade minikube and k8s version in integrations

### DIFF
--- a/.github/workflows/run-integration-tests-basic.yml
+++ b/.github/workflows/run-integration-tests-basic.yml
@@ -13,7 +13,7 @@ on:
 jobs:
    run-integration-test:
       name: Run Minikube Integration Tests
-      runs-on: ubuntu-latest
+      runs-on: ubuntu-22.04
       env:
          KUBECONFIG: /home/runner/.kube/config
          NAMESPACE: test-${{ github.run_id }}

--- a/.github/workflows/run-integration-tests-basic.yml
+++ b/.github/workflows/run-integration-tests-basic.yml
@@ -38,8 +38,8 @@ jobs:
            name: Setup Minikube
            uses: medyagh/setup-minikube@latest
            with:
-              minikube-version: 1.24.0
-              kubernetes-version: 1.22.3
+              minikube-version: 1.34.0
+              kubernetes-version: 1.31.0
               driver: 'none'
            timeout-minutes: 3
 

--- a/.github/workflows/run-integration-tests-bluegreen-ingress.yml
+++ b/.github/workflows/run-integration-tests-bluegreen-ingress.yml
@@ -13,7 +13,7 @@ on:
 jobs:
    run-integration-test:
       name: Run Minikube Integration Tests
-      runs-on: ubuntu-latest
+      runs-on: ubuntu-22.04
       env:
          KUBECONFIG: /home/runner/.kube/config
          NAMESPACE: test-${{ github.run_id }}

--- a/.github/workflows/run-integration-tests-bluegreen-ingress.yml
+++ b/.github/workflows/run-integration-tests-bluegreen-ingress.yml
@@ -38,8 +38,8 @@ jobs:
            name: Setup Minikube
            uses: medyagh/setup-minikube@latest
            with:
-              minikube-version: 1.31.2
-              kubernetes-version: 1.22.3
+              minikube-version: 1.34.0
+              kubernetes-version: 1.31.0
               driver: 'none'
            timeout-minutes: 3
 

--- a/.github/workflows/run-integration-tests-bluegreen-service.yml
+++ b/.github/workflows/run-integration-tests-bluegreen-service.yml
@@ -13,7 +13,7 @@ on:
 jobs:
    run-integration-test:
       name: Run Minikube Integration Tests
-      runs-on: ubuntu-latest
+      runs-on: ubuntu-22.04
       env:
          KUBECONFIG: /home/runner/.kube/config
          NAMESPACE: test-${{ github.run_id }}

--- a/.github/workflows/run-integration-tests-bluegreen-service.yml
+++ b/.github/workflows/run-integration-tests-bluegreen-service.yml
@@ -38,8 +38,8 @@ jobs:
            name: Setup Minikube
            uses: medyagh/setup-minikube@latest
            with:
-              minikube-version: 1.31.2
-              kubernetes-version: 1.22.3
+              minikube-version: 1.34.0
+              kubernetes-version: 1.31.0
               driver: 'none'
            timeout-minutes: 3
 

--- a/.github/workflows/run-integration-tests-bluegreen-smi.yml
+++ b/.github/workflows/run-integration-tests-bluegreen-smi.yml
@@ -38,8 +38,8 @@ jobs:
            name: Setup Minikube
            uses: medyagh/setup-minikube@latest
            with:
-              minikube-version: 1.31.2
-              kubernetes-version: 1.22.3
+              minikube-version: 1.34.0
+              kubernetes-version: 1.31.0
               driver: 'none'
            timeout-minutes: 3
 

--- a/.github/workflows/run-integration-tests-bluegreen-smi.yml
+++ b/.github/workflows/run-integration-tests-bluegreen-smi.yml
@@ -13,7 +13,7 @@ on:
 jobs:
    run-integration-test:
       name: Run Minikube Integration Tests
-      runs-on: ubuntu-latest
+      runs-on: ubuntu-22.04
       env:
          KUBECONFIG: /home/runner/.kube/config
          NAMESPACE: test-${{ github.run_id }}
@@ -38,7 +38,7 @@ jobs:
            name: Setup Minikube
            uses: medyagh/setup-minikube@latest
            with:
-              minikube-version: 1.24.0
+              minikube-version: 1.31.2
               kubernetes-version: 1.22.3
               driver: 'none'
            timeout-minutes: 3

--- a/.github/workflows/run-integration-tests-canary-pod.yml
+++ b/.github/workflows/run-integration-tests-canary-pod.yml
@@ -38,8 +38,8 @@ jobs:
            name: Setup Minikube
            uses: medyagh/setup-minikube@latest
            with:
-              minikube-version: 1.31.2
-              kubernetes-version: 1.22.3
+              minikube-version: 1.34.0
+              kubernetes-version: 1.31.0
               driver: 'none'
            timeout-minutes: 3
 

--- a/.github/workflows/run-integration-tests-canary-pod.yml
+++ b/.github/workflows/run-integration-tests-canary-pod.yml
@@ -13,7 +13,7 @@ on:
 jobs:
    run-integration-test:
       name: Run Minikube Integration Tests
-      runs-on: ubuntu-latest
+      runs-on: ubuntu-22.04
       env:
          KUBECONFIG: /home/runner/.kube/config
          NAMESPACE: test-${{ github.run_id }}
@@ -38,7 +38,7 @@ jobs:
            name: Setup Minikube
            uses: medyagh/setup-minikube@latest
            with:
-              minikube-version: 1.24.0
+              minikube-version: 1.31.2
               kubernetes-version: 1.22.3
               driver: 'none'
            timeout-minutes: 3

--- a/.github/workflows/run-integration-tests-canary-smi.yml
+++ b/.github/workflows/run-integration-tests-canary-smi.yml
@@ -38,8 +38,8 @@ jobs:
            name: Setup Minikube
            uses: medyagh/setup-minikube@latest
            with:
-              minikube-version: 1.31.2
-              kubernetes-version: 1.22.3
+              minikube-version: 1.34.0
+              kubernetes-version: 1.31.0
               driver: 'none'
            timeout-minutes: 3
 

--- a/.github/workflows/run-integration-tests-canary-smi.yml
+++ b/.github/workflows/run-integration-tests-canary-smi.yml
@@ -13,7 +13,7 @@ on:
 jobs:
    run-integration-test:
       name: Run Minikube Integration Tests
-      runs-on: ubuntu-latest
+      runs-on: ubuntu-22.04
       env:
          KUBECONFIG: /home/runner/.kube/config
          NAMESPACE: test-${{ github.run_id }}
@@ -38,7 +38,7 @@ jobs:
            name: Setup Minikube
            uses: medyagh/setup-minikube@latest
            with:
-              minikube-version: 1.24.0
+              minikube-version: 1.31.2
               kubernetes-version: 1.22.3
               driver: 'none'
            timeout-minutes: 3

--- a/.github/workflows/run-integration-tests-private.yml
+++ b/.github/workflows/run-integration-tests-private.yml
@@ -11,7 +11,7 @@ on:
 jobs:
    run-integration-test:
       name: Run Minikube Integration Tests
-      runs-on: ubuntu-latest
+      runs-on: ubuntu-22.04
       env:
          KUBECONFIG: /home/runner/.kube/config
          NAMESPACE: test-${{ github.run_id }}

--- a/.github/workflows/run-integration-tests-resource-annotation.yml
+++ b/.github/workflows/run-integration-tests-resource-annotation.yml
@@ -38,8 +38,8 @@ jobs:
            name: Setup Minikube
            uses: medyagh/setup-minikube@latest
            with:
-              minikube-version: 1.31.2
-              kubernetes-version: 1.22.3
+              minikube-version: 1.34.0
+              kubernetes-version: 1.31.0
               driver: 'none'
            timeout-minutes: 3
 

--- a/.github/workflows/run-integration-tests-resource-annotation.yml
+++ b/.github/workflows/run-integration-tests-resource-annotation.yml
@@ -13,7 +13,7 @@ on:
 jobs:
    run-integration-test:
       name: Run Minikube Integration Tests
-      runs-on: ubuntu-latest
+      runs-on: ubuntu-22.04
       env:
          KUBECONFIG: /home/runner/.kube/config
          NAMESPACE: test-${{ github.run_id }}
@@ -38,7 +38,7 @@ jobs:
            name: Setup Minikube
            uses: medyagh/setup-minikube@latest
            with:
-              minikube-version: 1.24.0
+              minikube-version: 1.31.2
               kubernetes-version: 1.22.3
               driver: 'none'
            timeout-minutes: 3


### PR DESCRIPTION
pin to ubuntu 22.04 until https://github.com/medyagh/setup-minikube/issues/565 is resolved, it's blocking our integration tests

upgrade minkube and k8s version in integrations

several tests are failing on PRs and this maintenance task is overdue