### PR TITLE
add gateway crds before installing smi

### DIFF
--- a/.github/workflows/run-integration-tests-bluegreen-smi.yml
+++ b/.github/workflows/run-integration-tests-bluegreen-smi.yml
@@ -45,9 +45,9 @@ jobs:
 
          - name: Install linkerd and add controlplane to cluster
            run: |
-              curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install | sh
-              curl -sL https://linkerd.github.io/linkerd-smi/install | sh
+              curl --proto '=https' --tlsv1.2 -sSfL https://run.linkerd.io/install-edge | sh
               export PATH=$PATH:/home/runner/.linkerd2/bin
+              kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.0/standard-install.yaml
 
               linkerd install --crds | kubectl apply -f -
               linkerd install --set proxyInit.runAsRoot=true | kubectl apply -f -

--- a/package-lock.json
+++ b/package-lock.json
@@ -2383,6 +2383,7 @@
          "resolved": "https://registry.npmjs.org/@vercel/ncc/-/ncc-0.38.3.tgz",
          "integrity": "sha512-rnK6hJBS6mwc+Bkab+PGPs9OiS0i/3kdTO+CkI8V0/VrW3vmz7O2Pxjw/owOlmo6PKEIxRSeZKv/kuL9itnpYA==",
          "dev": true,
+         "license": "MIT",
          "bin": {
             "ncc": "dist/ncc/cli.js"
          }


### PR DESCRIPTION
update linkerd install steps to include gateway CRDs, and use new linkerd install script as the old one is deprecated