### PR TITLE
Adding to action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -80,6 +80,10 @@ inputs:
    skip-tls-verify:
       description: True if the insecure-skip-tls-verify option should be used. Input should be 'true' or 'false'.
       default: false
+   resource-type:
+      description: Either Microsoft.ContainerService/managedClusters or Microsoft.ContainerService/fleets'.
+      required: false
+      default: 'Microsoft.ContainerService/managedClusters'
 
 branding:
    color: 'green'


### PR DESCRIPTION
Currently, not adding the new resource-type input in action.yml is causing this warning: 
![image](https://github.com/user-attachments/assets/26e69f33-6b77-49d2-bc73-76ab1828619c)
To avoid confusion, we will add it to remove the warning. 