### PR TITLE
case-insensitive resource type

### DIFF
--- a/src/actions/deploy.ts
+++ b/src/actions/deploy.ts
@@ -23,7 +23,8 @@ export type ClusterType =
 export async function deploy(
    kubectl: Kubectl,
    manifestFilePaths: string[],
-   deploymentStrategy: DeploymentStrategy
+   deploymentStrategy: DeploymentStrategy,
+   clusterType: ClusterType
 ) {
    // update manifests
    const inputManifestFiles: string[] = updateManifestFiles(manifestFilePaths)
@@ -45,8 +46,6 @@ export async function deploy(
 
    // check manifest stability
    core.startGroup('Checking manifest stability')
-   const resourceTypeInput =
-      core.getInput('resource-type') || ResourceTypeManagedCluster
    const resourceTypes: Resource[] = getResources(
       deployedManifestFiles,
       models.DEPLOYMENT_TYPES.concat([
@@ -54,16 +53,7 @@ export async function deploy(
       ])
    )
 
-   if (
-      resourceTypeInput !== ResourceTypeManagedCluster &&
-      resourceTypeInput !== ResourceTypeFleet
-   ) {
-      let errMsg = `Invalid resource type: ${resourceTypeInput}. Supported resource types are: ${ResourceTypeManagedCluster} (default), ${ResourceTypeFleet}`
-      core.setFailed(errMsg)
-      throw new Error(errMsg)
-   }
-
-   await checkManifestStability(kubectl, resourceTypes, resourceTypeInput)
+   await checkManifestStability(kubectl, resourceTypes, clusterType)
    core.endGroup()
 
    // print ingresses

--- a/src/actions/deploy.ts
+++ b/src/actions/deploy.ts
@@ -13,18 +13,15 @@ import {
 } from '../strategyHelpers/deploymentHelper'
 import {DeploymentStrategy} from '../types/deploymentStrategy'
 import {parseTrafficSplitMethod} from '../types/trafficSplitMethod'
+import {ClusterType} from '../inputUtils'
 export const ResourceTypeManagedCluster =
    'Microsoft.ContainerService/managedClusters'
 export const ResourceTypeFleet = 'Microsoft.ContainerService/fleets'
-export type ClusterType =
-   | typeof ResourceTypeManagedCluster
-   | typeof ResourceTypeFleet
-
 export async function deploy(
    kubectl: Kubectl,
    manifestFilePaths: string[],
    deploymentStrategy: DeploymentStrategy,
-   clusterType: ClusterType
+   resourceType: ClusterType
 ) {
    // update manifests
    const inputManifestFiles: string[] = updateManifestFiles(manifestFilePaths)
@@ -53,7 +50,7 @@ export async function deploy(
       ])
    )
 
-   await checkManifestStability(kubectl, resourceTypes, clusterType)
+   await checkManifestStability(kubectl, resourceTypes, resourceType)
    core.endGroup()
 
    // print ingresses

--- a/src/actions/promote.ts
+++ b/src/actions/promote.ts
@@ -6,7 +6,7 @@ import {
    getResources,
    updateManifestFiles
 } from '../utilities/manifestUpdateUtils'
-import {annotateAndLabelResources} from '../strategyHelpers/deploymentHelper'
+import { annotateAndLabelResources } from '../strategyHelpers/deploymentHelper'
 import * as models from '../types/kubernetesTypes'
 import * as KubernetesManifestUtility from '../utilities/manifestStabilityUtils'
 import {
@@ -15,8 +15,8 @@ import {
    NONE_LABEL_VALUE
 } from '../strategyHelpers/blueGreen/blueGreenHelper'
 
-import {BlueGreenManifests} from '../types/blueGreenTypes'
-import {DeployResult} from '../types/deployResult'
+import { BlueGreenManifests } from '../types/blueGreenTypes'
+import { DeployResult } from '../types/deployResult'
 
 import {
    promoteBlueGreenIngress,
@@ -30,15 +30,15 @@ import {
    routeBlueGreenSMI
 } from '../strategyHelpers/blueGreen/route'
 
-import {cleanupSMI} from '../strategyHelpers/blueGreen/smiBlueGreenHelper'
-import {Kubectl, Resource} from '../types/kubectl'
-import {DeploymentStrategy} from '../types/deploymentStrategy'
+import { cleanupSMI } from '../strategyHelpers/blueGreen/smiBlueGreenHelper'
+import { Kubectl, Resource } from '../types/kubectl'
+import { DeploymentStrategy } from '../types/deploymentStrategy'
 import {
    parseTrafficSplitMethod,
    TrafficSplitMethod
 } from '../types/trafficSplitMethod'
-import {parseRouteStrategy, RouteStrategy} from '../types/routeStrategy'
-import {ClusterType} from '../inputUtils'
+import { parseRouteStrategy, RouteStrategy } from '../types/routeStrategy'
+import { ClusterType } from '../inputUtils'
 
 export async function promote(
    kubectl: Kubectl,
@@ -64,7 +64,7 @@ async function promoteCanary(kubectl: Kubectl, manifests: string[]) {
    const manifestFilesForDeployment: string[] = updateManifestFiles(manifests)
 
    const trafficSplitMethod = parseTrafficSplitMethod(
-      core.getInput('traffic-split-method', {required: true})
+      core.getInput('traffic-split-method', { required: true })
    )
    let promoteResult: DeployResult
    let filesToAnnotate: string[]
@@ -144,7 +144,7 @@ async function promoteCanary(kubectl: Kubectl, manifests: string[]) {
 async function promoteBlueGreen(
    kubectl: Kubectl,
    manifests: string[],
-   clusterType: ClusterType
+   resourceType: ClusterType
 ) {
    // update container images and pull secrets
    const inputManifestFiles: string[] = updateManifestFiles(manifests)
@@ -152,12 +152,12 @@ async function promoteBlueGreen(
       getManifestObjects(inputManifestFiles)
 
    const routeStrategy = parseRouteStrategy(
-      core.getInput('route-method', {required: true})
+      core.getInput('route-method', { required: true })
    )
 
    core.startGroup('Deleting old deployment and making new stable deployment')
 
-   const {deployResult} = await (async () => {
+   const { deployResult } = await (async () => {
       switch (routeStrategy) {
          case RouteStrategy.INGRESS:
             return await promoteBlueGreenIngress(kubectl, manifestObjects)
@@ -182,7 +182,7 @@ async function promoteBlueGreen(
    await KubernetesManifestUtility.checkManifestStability(
       kubectl,
       resources,
-      clusterType
+      resourceType
    )
    core.endGroup()
 

--- a/src/actions/promote.ts
+++ b/src/actions/promote.ts
@@ -6,7 +6,7 @@ import {
    getResources,
    updateManifestFiles
 } from '../utilities/manifestUpdateUtils'
-import { annotateAndLabelResources } from '../strategyHelpers/deploymentHelper'
+import {annotateAndLabelResources} from '../strategyHelpers/deploymentHelper'
 import * as models from '../types/kubernetesTypes'
 import * as KubernetesManifestUtility from '../utilities/manifestStabilityUtils'
 import {
@@ -15,8 +15,8 @@ import {
    NONE_LABEL_VALUE
 } from '../strategyHelpers/blueGreen/blueGreenHelper'
 
-import { BlueGreenManifests } from '../types/blueGreenTypes'
-import { DeployResult } from '../types/deployResult'
+import {BlueGreenManifests} from '../types/blueGreenTypes'
+import {DeployResult} from '../types/deployResult'
 
 import {
    promoteBlueGreenIngress,
@@ -30,15 +30,15 @@ import {
    routeBlueGreenSMI
 } from '../strategyHelpers/blueGreen/route'
 
-import { cleanupSMI } from '../strategyHelpers/blueGreen/smiBlueGreenHelper'
-import { Kubectl, Resource } from '../types/kubectl'
-import { DeploymentStrategy } from '../types/deploymentStrategy'
+import {cleanupSMI} from '../strategyHelpers/blueGreen/smiBlueGreenHelper'
+import {Kubectl, Resource} from '../types/kubectl'
+import {DeploymentStrategy} from '../types/deploymentStrategy'
 import {
    parseTrafficSplitMethod,
    TrafficSplitMethod
 } from '../types/trafficSplitMethod'
-import { parseRouteStrategy, RouteStrategy } from '../types/routeStrategy'
-import { ClusterType } from '../inputUtils'
+import {parseRouteStrategy, RouteStrategy} from '../types/routeStrategy'
+import {ClusterType} from '../inputUtils'
 
 export async function promote(
    kubectl: Kubectl,
@@ -64,7 +64,7 @@ async function promoteCanary(kubectl: Kubectl, manifests: string[]) {
    const manifestFilesForDeployment: string[] = updateManifestFiles(manifests)
 
    const trafficSplitMethod = parseTrafficSplitMethod(
-      core.getInput('traffic-split-method', { required: true })
+      core.getInput('traffic-split-method', {required: true})
    )
    let promoteResult: DeployResult
    let filesToAnnotate: string[]
@@ -152,12 +152,12 @@ async function promoteBlueGreen(
       getManifestObjects(inputManifestFiles)
 
    const routeStrategy = parseRouteStrategy(
-      core.getInput('route-method', { required: true })
+      core.getInput('route-method', {required: true})
    )
 
    core.startGroup('Deleting old deployment and making new stable deployment')
 
-   const { deployResult } = await (async () => {
+   const {deployResult} = await (async () => {
       switch (routeStrategy) {
          case RouteStrategy.INGRESS:
             return await promoteBlueGreenIngress(kubectl, manifestObjects)

--- a/src/actions/promote.ts
+++ b/src/actions/promote.ts
@@ -38,23 +38,20 @@ import {
    TrafficSplitMethod
 } from '../types/trafficSplitMethod'
 import {parseRouteStrategy, RouteStrategy} from '../types/routeStrategy'
-import {
-   ClusterType,
-   ResourceTypeFleet,
-   ResourceTypeManagedCluster
-} from './deploy'
+import {ClusterType} from '../inputUtils'
 
 export async function promote(
    kubectl: Kubectl,
    manifests: string[],
-   deploymentStrategy: DeploymentStrategy
+   deploymentStrategy: DeploymentStrategy,
+   resourceType: ClusterType
 ) {
    switch (deploymentStrategy) {
       case DeploymentStrategy.CANARY:
          await promoteCanary(kubectl, manifests)
          break
       case DeploymentStrategy.BLUE_GREEN:
-         await promoteBlueGreen(kubectl, manifests)
+         await promoteBlueGreen(kubectl, manifests, resourceType)
          break
       default:
          throw Error('Invalid promote deployment strategy')

--- a/src/inputUtils.test.ts
+++ b/src/inputUtils.test.ts
@@ -1,0 +1,34 @@
+import {parseResourceTypeInput} from './inputUtils'
+import {
+   ClusterType,
+   ResourceTypeFleet,
+   ResourceTypeManagedCluster
+} from './actions/deploy'
+
+describe('InputUtils', () => {
+   describe('parseResourceTypeInput', () => {
+      it('should extract fleet exact match resource type', () => {
+         expect(
+            parseResourceTypeInput('Microsoft.ContainerService/fleets')
+         ).toEqual(ResourceTypeFleet)
+      })
+      it('should match fleet case-insensitively', () => {
+         expect(
+            parseResourceTypeInput('Microsoft.containerservice/fleets')
+         ).toEqual(ResourceTypeFleet)
+      })
+      it('should match managed cluster case-insensitively', () => {
+         expect(
+            parseResourceTypeInput('Microsoft.containerservice/MAnaGedClusterS')
+         ).toEqual(ResourceTypeManagedCluster)
+      })
+      it('should error on unexpected values', () => {
+         expect(() => {
+            parseResourceTypeInput('icrosoft.ContainerService/ManagedCluster')
+         }).toThrow()
+         expect(() => {
+            parseResourceTypeInput('wrong-value')
+         }).toThrow()
+      })
+   })
+})

--- a/src/inputUtils.ts
+++ b/src/inputUtils.ts
@@ -1,13 +1,9 @@
 import * as core from '@actions/core'
-import { parseAnnotations } from './types/annotations'
-import {
-   ClusterType,
-   ResourceTypeFleet,
-   ResourceTypeManagedCluster
-} from './actions/deploy'
+import {parseAnnotations} from './types/annotations'
+import {ResourceTypeFleet, ResourceTypeManagedCluster} from './actions/deploy'
 
 export const inputAnnotations = parseAnnotations(
-   core.getInput('annotations', { required: false })
+   core.getInput('annotations', {required: false})
 )
 
 export function getBufferTime(): number {
@@ -31,3 +27,6 @@ export function parseResourceTypeInput(rawInput: string): ClusterType {
       `Invalid resource type: ${rawInput}. Supported resource types are: ${ResourceTypeManagedCluster} (default), ${ResourceTypeFleet}`
    )
 }
+export type ClusterType =
+   | typeof ResourceTypeManagedCluster
+   | typeof ResourceTypeFleet

--- a/src/inputUtils.ts
+++ b/src/inputUtils.ts
@@ -1,5 +1,10 @@
 import * as core from '@actions/core'
 import {parseAnnotations} from './types/annotations'
+import {
+   ClusterType,
+   ResourceTypeFleet,
+   ResourceTypeManagedCluster
+} from './actions/deploy'
 
 export const inputAnnotations = parseAnnotations(
    core.getInput('annotations', {required: false})
@@ -13,4 +18,16 @@ export function getBufferTime(): number {
       throw Error('Version switch buffer must be between 0 and 300 (inclusive)')
 
    return inputBufferTime
+}
+
+export function parseResourceTypeInput(rawInput: string): ClusterType {
+   switch (rawInput.toLowerCase()) {
+      case ResourceTypeFleet.toLowerCase():
+         return ResourceTypeFleet
+      case ResourceTypeManagedCluster.toLowerCase():
+         return ResourceTypeManagedCluster
+      default:
+         let errMsg = `Invalid resource type: ${rawInput}. Supported resource types are: ${ResourceTypeManagedCluster} (default), ${ResourceTypeFleet}`
+         throw new Error(errMsg)
+   }
 }

--- a/src/inputUtils.ts
+++ b/src/inputUtils.ts
@@ -1,5 +1,5 @@
 import * as core from '@actions/core'
-import {parseAnnotations} from './types/annotations'
+import { parseAnnotations } from './types/annotations'
 import {
    ClusterType,
    ResourceTypeFleet,
@@ -7,7 +7,7 @@ import {
 } from './actions/deploy'
 
 export const inputAnnotations = parseAnnotations(
-   core.getInput('annotations', {required: false})
+   core.getInput('annotations', { required: false })
 )
 
 export function getBufferTime(): number {
@@ -26,8 +26,8 @@ export function parseResourceTypeInput(rawInput: string): ClusterType {
          return ResourceTypeFleet
       case ResourceTypeManagedCluster.toLowerCase():
          return ResourceTypeManagedCluster
-      default:
-         let errMsg = `Invalid resource type: ${rawInput}. Supported resource types are: ${ResourceTypeManagedCluster} (default), ${ResourceTypeFleet}`
-         throw new Error(errMsg)
    }
+   throw new Error(
+      `Invalid resource type: ${rawInput}. Supported resource types are: ${ResourceTypeManagedCluster} (default), ${ResourceTypeFleet}`
+   )
 }

--- a/src/run.ts
+++ b/src/run.ts
@@ -42,9 +42,10 @@ export async function run() {
    const resourceName = core.getInput('name') || ''
    const skipTlsVerify = core.getBooleanInput('skip-tls-verify')
 
-   const resourceTypeInput = core.getInput('resource-type')
    let resourceType: ClusterType
    try {
+      // included in the trycatch to allow raw input to go out of scope after parsing
+      const resourceTypeInput = core.getInput('resource-type')
       resourceType = parseResourceTypeInput(resourceTypeInput)
    } catch (e) {
       core.setFailed(e)

--- a/src/run.ts
+++ b/src/run.ts
@@ -43,7 +43,13 @@ export async function run() {
    const skipTlsVerify = core.getBooleanInput('skip-tls-verify')
 
    const resourceTypeInput = core.getInput('resource-type')
-   const resourceType = parseResourceTypeInput(resourceTypeInput)
+   let resourceType: ClusterType
+   try {
+      resourceType = parseResourceTypeInput(resourceTypeInput)
+   } catch (e) {
+      core.setFailed(e)
+      return
+   }
 
    const kubectl = isPrivateCluster
       ? new PrivateKubectl(
@@ -62,7 +68,7 @@ export async function run() {
          break
       }
       case Action.PROMOTE: {
-         await promote(kubectl, fullManifestFilePaths, strategy)
+         await promote(kubectl, fullManifestFilePaths, strategy, resourceType)
          break
       }
       case Action.REJECT: {

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,11 +1,11 @@
 import * as core from '@actions/core'
 import {getKubectlPath, Kubectl} from './types/kubectl'
 import {
-   ClusterType,
    deploy,
    ResourceTypeFleet,
    ResourceTypeManagedCluster
 } from './actions/deploy'
+import {ClusterType} from './inputUtils'
 import {promote} from './actions/promote'
 import {reject} from './actions/reject'
 import {Action, parseAction} from './types/action'

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,18 +1,18 @@
 import * as core from '@actions/core'
-import { getKubectlPath, Kubectl } from './types/kubectl'
+import {getKubectlPath, Kubectl} from './types/kubectl'
 import {
    ClusterType,
    deploy,
    ResourceTypeFleet,
    ResourceTypeManagedCluster
 } from './actions/deploy'
-import { promote } from './actions/promote'
-import { reject } from './actions/reject'
-import { Action, parseAction } from './types/action'
-import { parseDeploymentStrategy } from './types/deploymentStrategy'
-import { getFilesFromDirectoriesAndURLs } from './utilities/fileUtils'
-import { PrivateKubectl } from './types/privatekubectl'
-import { parseResourceTypeInput } from './inputUtils'
+import {promote} from './actions/promote'
+import {reject} from './actions/reject'
+import {Action, parseAction} from './types/action'
+import {parseDeploymentStrategy} from './types/deploymentStrategy'
+import {getFilesFromDirectoriesAndURLs} from './utilities/fileUtils'
+import {PrivateKubectl} from './types/privatekubectl'
+import {parseResourceTypeInput} from './inputUtils'
 
 export async function run() {
    // verify kubeconfig is set
@@ -23,10 +23,10 @@ export async function run() {
 
    // get inputs
    const action: Action | undefined = parseAction(
-      core.getInput('action', { required: true })
+      core.getInput('action', {required: true})
    )
    const strategy = parseDeploymentStrategy(core.getInput('strategy'))
-   const manifestsInput = core.getInput('manifests', { required: true })
+   const manifestsInput = core.getInput('manifests', {required: true})
    const manifestFilePaths = manifestsInput
       .split(/[\n,;]+/) // split into each individual manifest
       .map((manifest) => manifest.trim()) // remove surrounding whitespace
@@ -47,12 +47,12 @@ export async function run() {
 
    const kubectl = isPrivateCluster
       ? new PrivateKubectl(
-         kubectlPath,
-         namespace,
-         skipTlsVerify,
-         resourceGroup,
-         resourceName
-      )
+           kubectlPath,
+           namespace,
+           skipTlsVerify,
+           resourceGroup,
+           resourceName
+        )
       : new Kubectl(kubectlPath, namespace, skipTlsVerify)
 
    // run action

--- a/src/strategyHelpers/deploymentHelper.ts
+++ b/src/strategyHelpers/deploymentHelper.ts
@@ -35,7 +35,7 @@ import {
 } from '../utilities/githubUtils'
 import {getDeploymentConfig} from '../utilities/dockerUtils'
 import {DeployResult} from '../types/deployResult'
-import {ClusterType} from '../actions/deploy'
+import {ClusterType} from '../inputUtils'
 
 export async function deployManifests(
    files: string[],

--- a/src/utilities/manifestStabilityUtils.ts
+++ b/src/utilities/manifestStabilityUtils.ts
@@ -3,7 +3,8 @@ import * as KubernetesConstants from '../types/kubernetesTypes'
 import {Kubectl, Resource} from '../types/kubectl'
 import {checkForErrors} from './kubectlUtils'
 import {sleep} from './timeUtils'
-import {ClusterType, ResourceTypeFleet} from '../actions/deploy'
+import {ResourceTypeFleet} from '../actions/deploy'
+import {ClusterType} from '../inputUtils'
 
 const IS_SILENT = false
 const POD = 'pod'
@@ -11,10 +12,10 @@ const POD = 'pod'
 export async function checkManifestStability(
    kubectl: Kubectl,
    resources: Resource[],
-   clusterType: ClusterType
+   resourceType: ClusterType
 ): Promise<void> {
    // Skip if resource type is microsoft.containerservice/fleets
-   if (clusterType === ResourceTypeFleet) {
+   if (resourceType === ResourceTypeFleet) {
       core.info(`Skipping checkManifestStability for ${ResourceTypeFleet}`)
       return
    }

--- a/src/utilities/manifestStabilityUtils.ts
+++ b/src/utilities/manifestStabilityUtils.ts
@@ -11,10 +11,10 @@ const POD = 'pod'
 export async function checkManifestStability(
    kubectl: Kubectl,
    resources: Resource[],
-   clusterTyper: ClusterType
+   clusterType: ClusterType
 ): Promise<void> {
    // Skip if resource type is microsoft.containerservice/fleets
-   if (clusterTyper === ResourceTypeFleet) {
+   if (clusterType === ResourceTypeFleet) {
       core.info(`Skipping checkManifestStability for ${ResourceTypeFleet}`)
       return
    }


### PR DESCRIPTION
- allow case-insensitive matching of resource types
- centralize core.getInput retrieval to run.ts for `resourceType`
- add tests for case-insensitive resource type and throw on unknown resource type