### PR TITLE
add server-side option for kubectl apply commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,10 @@ Following are the key capabilities of this action:
     <td>Deploy when a previous deployment already exists. If true then '--force' argument is added to the apply command. Using '--force' argument is not recommended in production.</td>
   </tr>
   <tr>
+    <td>server-side </br></br>(Optional)</td>
+    <td>The apply command runs in the server instead of the client. If true then '--server-side' argument is added to the apply command.</td>
+  </tr>
+  <tr>
     <td>annotate-resources</br></br>(Optional)</td>
     <td>Acceptable values: true/false</br>Default value: true</br>Switch whether to annotate the resources or not. If set to false all annotations are skipped completely.</td>
   </tr>

--- a/action.yml
+++ b/action.yml
@@ -55,6 +55,10 @@ inputs:
       description: 'Deploy when a previous deployment already exists. If true then --force argument is added to the apply command'
       required: false
       default: false
+   server-side:
+      description: 'The apply command runs in the server instead of the client. If true then --server-side argument is added to the apply command.'
+      required: false
+      default: false
    token:
       description: 'Github token'
       default: ${{ github.token }}

--- a/src/strategyHelpers/blueGreen/blueGreenHelper.ts
+++ b/src/strategyHelpers/blueGreen/blueGreenHelper.ts
@@ -270,7 +270,13 @@ export async function deployObjects(
    objectsList: any[]
 ): Promise<DeployResult> {
    const manifestFiles = fileHelper.writeObjectsToFile(objectsList)
-   const execResult = await kubectl.apply(manifestFiles)
+   const forceDeployment = core.getInput('force').toLowerCase() === 'true'
+   const serverSideApply = core.getInput('server-side').toLowerCase() === 'true'
+   const execResult = await kubectl.apply(
+      manifestFiles,
+      forceDeployment,
+      serverSideApply
+   )
 
    return {execResult, manifestFiles}
 }

--- a/src/strategyHelpers/canary/podCanaryHelper.ts
+++ b/src/strategyHelpers/canary/podCanaryHelper.ts
@@ -95,8 +95,13 @@ export async function deployPodCanary(
    core.debug('New objects list: ' + JSON.stringify(newObjectsList))
    const manifestFiles = fileHelper.writeObjectsToFile(newObjectsList)
    const forceDeployment = core.getInput('force').toLowerCase() === 'true'
+   const serverSideApply = core.getInput('server-side').toLowerCase() === 'true'
 
-   const execResult = await kubectl.apply(manifestFiles, forceDeployment)
+   const execResult = await kubectl.apply(
+      manifestFiles,
+      forceDeployment,
+      serverSideApply
+   )
    return {execResult, manifestFiles}
 }
 

--- a/src/strategyHelpers/canary/smiCanaryHelper.ts
+++ b/src/strategyHelpers/canary/smiCanaryHelper.ts
@@ -106,7 +106,12 @@ export async function deploySMICanary(
    )
    const newFilePaths = fileHelper.writeObjectsToFile(newObjectsList)
    const forceDeployment = core.getInput('force').toLowerCase() === 'true'
-   const result = await kubectl.apply(newFilePaths, forceDeployment)
+   const serverSideApply = core.getInput('server-side').toLowerCase() === 'true'
+   const result = await kubectl.apply(
+      newFilePaths,
+      forceDeployment,
+      serverSideApply
+   )
    const svcDeploymentFiles = await createCanaryService(kubectl, filePaths)
    newFilePaths.push(...svcDeploymentFiles)
    return {execResult: result, manifestFiles: newFilePaths}
@@ -210,8 +215,13 @@ async function createCanaryService(
    const manifestFiles = fileHelper.writeObjectsToFile(newObjectsList)
    manifestFiles.push(...trafficObjectsList)
    const forceDeployment = core.getInput('force').toLowerCase() === 'true'
+   const serverSideApply = core.getInput('server-side').toLowerCase() === 'true'
 
-   const result = await kubectl.apply(manifestFiles, forceDeployment)
+   const result = await kubectl.apply(
+      manifestFiles,
+      forceDeployment,
+      serverSideApply
+   )
    checkForErrors([result])
    return manifestFiles
 }
@@ -275,7 +285,12 @@ async function adjustTraffic(
    }
 
    const forceDeployment = core.getInput('force').toLowerCase() === 'true'
-   const result = await kubectl.apply(trafficSplitManifests, forceDeployment)
+   const serverSideApply = core.getInput('server-side').toLowerCase() === 'true'
+   const result = await kubectl.apply(
+      trafficSplitManifests,
+      forceDeployment,
+      serverSideApply
+   )
    checkForErrors([result])
    return trafficSplitManifests
 }

--- a/src/strategyHelpers/deploymentHelper.ts
+++ b/src/strategyHelpers/deploymentHelper.ts
@@ -84,16 +84,23 @@ export async function deployManifests(
          )
 
          const forceDeployment = core.getInput('force').toLowerCase() === 'true'
+         const serverSideApply =
+            core.getInput('server-side').toLowerCase() === 'true'
          if (trafficSplitMethod === TrafficSplitMethod.SMI) {
             const updatedManifests = appendStableVersionLabelToResource(files)
 
             const result = await kubectl.apply(
                updatedManifests,
-               forceDeployment
+               forceDeployment,
+               serverSideApply
             )
             checkForErrors([result])
          } else {
-            const result = await kubectl.apply(files, forceDeployment)
+            const result = await kubectl.apply(
+               files,
+               forceDeployment,
+               serverSideApply
+            )
             checkForErrors([result])
          }
 

--- a/src/types/kubectl.test.ts
+++ b/src/types/kubectl.test.ts
@@ -95,6 +95,43 @@ describe('Kubectl class', () => {
          )
       })
 
+      it('applies a configuration with server-side when specified', async () => {
+         const configPaths = ['configPath1', 'configPath2', 'configPath3']
+         const result = await kubectl.apply(configPaths, false, true)
+         expect(result).toBe(execReturn)
+         expect(exec.getExecOutput).toHaveBeenCalledWith(
+            kubectlPath,
+            [
+               'apply',
+               '-f',
+               configPaths[0] + ',' + configPaths[1] + ',' + configPaths[2],
+               '--server-side',
+               '--namespace',
+               testNamespace
+            ],
+            {silent: false}
+         )
+      })
+
+      it('applies a configuration with both force and server-side when specified', async () => {
+         const configPaths = ['configPath1', 'configPath2', 'configPath3']
+         const result = await kubectl.apply(configPaths, true, true)
+         expect(result).toBe(execReturn)
+         expect(exec.getExecOutput).toHaveBeenCalledWith(
+            kubectlPath,
+            [
+               'apply',
+               '-f',
+               configPaths[0] + ',' + configPaths[1] + ',' + configPaths[2],
+               '--force',
+               '--server-side',
+               '--namespace',
+               testNamespace
+            ],
+            {silent: false}
+         )
+      })
+
       it('describes a resource', async () => {
          const resourceType = 'type'
          const resourceName = 'name'

--- a/src/types/kubectl.ts
+++ b/src/types/kubectl.ts
@@ -34,7 +34,8 @@ export class Kubectl {
 
    public async apply(
       configurationPaths: string | string[],
-      force: boolean = false
+      force: boolean = false,
+      serverSide: boolean = false
    ): Promise<ExecOutput> {
       try {
          if (!configurationPaths || configurationPaths?.length === 0)
@@ -46,6 +47,7 @@ export class Kubectl {
             createInlineArray(configurationPaths)
          ]
          if (force) applyArgs.push('--force')
+         if (serverSide) applyArgs.push('--server-side')
 
          return await this.execute(applyArgs.concat(this.getFlags()))
       } catch (err) {


### PR DESCRIPTION
- Add serverSide parameter to kubectl.apply() method
- Update all deployment strategy helpers to support server-side flag
- Add comprehensive unit tests for server-side functionality
- Follow existing force option implementation pattern
- Maintain backward compatibility with optional parameter
Addresses PR #312 and fixes issue #311 
Credits to @krikooo for the first #312 