### PR TITLE
release: prepare v6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [6.0.0] - 2026-04-17
+
+### Changed
+
+- #504 [Update Node.js runtime from node20 to node24](https://github.com/Azure/k8s-deploy/pull/504)
+- #500 [Update action version references in README to latest majors](https://github.com/Azure/k8s-deploy/pull/500)
+
+### Security
+
+- #506 [Bump undici from 6.23.0 to 6.24.1](https://github.com/Azure/k8s-deploy/pull/506)
+- #513 [Bump vite from 8.0.3 to 8.0.5](https://github.com/Azure/k8s-deploy/pull/513)
+- #509 [Bump the actions group across 1 directory with 4 updates](https://github.com/Azure/k8s-deploy/pull/509)
+- #510 [Bump the actions group across 1 directory with 2 updates](https://github.com/Azure/k8s-deploy/pull/510)
+- #511 [Bump vitest from 4.1.1 to 4.1.2](https://github.com/Azure/k8s-deploy/pull/511)
+- #514 [Bump the actions group with 2 updates](https://github.com/Azure/k8s-deploy/pull/514)
+- #501 [Bump @types/node from 25.3.3 to 25.4.0](https://github.com/Azure/k8s-deploy/pull/501)
+
 ## [5.1.0] - 2026-03-03
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
    "name": "k8s-deploy-action",
-   "version": "5.1.0",
+   "version": "6.0.0",
    "lockfileVersion": 3,
    "requires": true,
    "packages": {
       "": {
          "name": "k8s-deploy-action",
-         "version": "5.1.0",
+         "version": "6.0.0",
          "license": "MIT",
          "dependencies": {
             "@actions/core": "^3.0.0",
@@ -78,38 +78,35 @@
          }
       },
       "node_modules/@emnapi/core": {
-         "version": "1.9.1",
-         "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
-         "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
+         "version": "1.9.2",
+         "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+         "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
          "dev": true,
          "license": "MIT",
          "optional": true,
-         "peer": true,
          "dependencies": {
-            "@emnapi/wasi-threads": "1.2.0",
+            "@emnapi/wasi-threads": "1.2.1",
             "tslib": "^2.4.0"
          }
       },
       "node_modules/@emnapi/runtime": {
-         "version": "1.9.1",
-         "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
-         "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+         "version": "1.9.2",
+         "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+         "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
          "dev": true,
          "license": "MIT",
          "optional": true,
-         "peer": true,
          "dependencies": {
             "tslib": "^2.4.0"
          }
       },
       "node_modules/@emnapi/wasi-threads": {
-         "version": "1.2.0",
-         "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
-         "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+         "version": "1.2.1",
+         "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+         "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
          "dev": true,
          "license": "MIT",
          "optional": true,
-         "peer": true,
          "dependencies": {
             "tslib": "^2.4.0"
          }
@@ -564,9 +561,9 @@
          "license": "MIT"
       },
       "node_modules/@napi-rs/wasm-runtime": {
-         "version": "1.1.2",
-         "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.2.tgz",
-         "integrity": "sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==",
+         "version": "1.1.4",
+         "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+         "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
          "dev": true,
          "license": "MIT",
          "optional": true,
@@ -610,9 +607,9 @@
          }
       },
       "node_modules/@octokit/endpoint": {
-         "version": "11.0.2",
-         "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.2.tgz",
-         "integrity": "sha512-4zCpzP1fWc7QlqunZ5bSEjxc6yLAlRTnDwKtgXfcI/FxxGoqedDG8V2+xJ60bV2kODqcGB+nATdtap/XYq2NZQ==",
+         "version": "11.0.3",
+         "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.3.tgz",
+         "integrity": "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==",
          "license": "MIT",
          "dependencies": {
             "@octokit/types": "^16.0.0",
@@ -660,15 +657,16 @@
          }
       },
       "node_modules/@octokit/request": {
-         "version": "10.0.7",
-         "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.7.tgz",
-         "integrity": "sha512-v93h0i1yu4idj8qFPZwjehoJx4j3Ntn+JhXsdJrG9pYaX6j/XRz2RmasMUHtNgQD39nrv/VwTWSqK0RNXR8upA==",
+         "version": "10.0.8",
+         "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.8.tgz",
+         "integrity": "sha512-SJZNwY9pur9Agf7l87ywFi14W+Hd9Jg6Ifivsd33+/bGUQIjNujdFiXII2/qSlN2ybqUHfp5xpekMEjIBTjlSw==",
          "license": "MIT",
          "dependencies": {
-            "@octokit/endpoint": "^11.0.2",
+            "@octokit/endpoint": "^11.0.3",
             "@octokit/request-error": "^7.0.2",
             "@octokit/types": "^16.0.0",
             "fast-content-type-parse": "^3.0.0",
+            "json-with-bigint": "^3.5.3",
             "universal-user-agent": "^7.0.2"
          },
          "engines": {
@@ -697,9 +695,9 @@
          }
       },
       "node_modules/@oxc-project/types": {
-         "version": "0.122.0",
-         "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.122.0.tgz",
-         "integrity": "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==",
+         "version": "0.124.0",
+         "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
+         "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
          "dev": true,
          "license": "MIT",
          "funding": {
@@ -707,9 +705,9 @@
          }
       },
       "node_modules/@rolldown/binding-android-arm64": {
-         "version": "1.0.0-rc.12",
-         "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.12.tgz",
-         "integrity": "sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==",
+         "version": "1.0.0-rc.15",
+         "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
+         "integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
          "cpu": [
             "arm64"
          ],
@@ -724,9 +722,9 @@
          }
       },
       "node_modules/@rolldown/binding-darwin-arm64": {
-         "version": "1.0.0-rc.12",
-         "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.12.tgz",
-         "integrity": "sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==",
+         "version": "1.0.0-rc.15",
+         "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.15.tgz",
+         "integrity": "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==",
          "cpu": [
             "arm64"
          ],
@@ -741,9 +739,9 @@
          }
       },
       "node_modules/@rolldown/binding-darwin-x64": {
-         "version": "1.0.0-rc.12",
-         "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.12.tgz",
-         "integrity": "sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==",
+         "version": "1.0.0-rc.15",
+         "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
+         "integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
          "cpu": [
             "x64"
          ],
@@ -758,9 +756,9 @@
          }
       },
       "node_modules/@rolldown/binding-freebsd-x64": {
-         "version": "1.0.0-rc.12",
-         "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.12.tgz",
-         "integrity": "sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==",
+         "version": "1.0.0-rc.15",
+         "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
+         "integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
          "cpu": [
             "x64"
          ],
@@ -775,9 +773,9 @@
          }
       },
       "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-         "version": "1.0.0-rc.12",
-         "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.12.tgz",
-         "integrity": "sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==",
+         "version": "1.0.0-rc.15",
+         "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
+         "integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
          "cpu": [
             "arm"
          ],
@@ -792,9 +790,9 @@
          }
       },
       "node_modules/@rolldown/binding-linux-arm64-gnu": {
-         "version": "1.0.0-rc.12",
-         "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.12.tgz",
-         "integrity": "sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==",
+         "version": "1.0.0-rc.15",
+         "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
+         "integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
          "cpu": [
             "arm64"
          ],
@@ -809,9 +807,9 @@
          }
       },
       "node_modules/@rolldown/binding-linux-arm64-musl": {
-         "version": "1.0.0-rc.12",
-         "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.12.tgz",
-         "integrity": "sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==",
+         "version": "1.0.0-rc.15",
+         "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
+         "integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
          "cpu": [
             "arm64"
          ],
@@ -826,9 +824,9 @@
          }
       },
       "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-         "version": "1.0.0-rc.12",
-         "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.12.tgz",
-         "integrity": "sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==",
+         "version": "1.0.0-rc.15",
+         "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
+         "integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
          "cpu": [
             "ppc64"
          ],
@@ -843,9 +841,9 @@
          }
       },
       "node_modules/@rolldown/binding-linux-s390x-gnu": {
-         "version": "1.0.0-rc.12",
-         "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.12.tgz",
-         "integrity": "sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==",
+         "version": "1.0.0-rc.15",
+         "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
+         "integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
          "cpu": [
             "s390x"
          ],
@@ -860,9 +858,9 @@
          }
       },
       "node_modules/@rolldown/binding-linux-x64-gnu": {
-         "version": "1.0.0-rc.12",
-         "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.12.tgz",
-         "integrity": "sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==",
+         "version": "1.0.0-rc.15",
+         "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
+         "integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
          "cpu": [
             "x64"
          ],
@@ -877,9 +875,9 @@
          }
       },
       "node_modules/@rolldown/binding-linux-x64-musl": {
-         "version": "1.0.0-rc.12",
-         "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.12.tgz",
-         "integrity": "sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==",
+         "version": "1.0.0-rc.15",
+         "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
+         "integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
          "cpu": [
             "x64"
          ],
@@ -894,9 +892,9 @@
          }
       },
       "node_modules/@rolldown/binding-openharmony-arm64": {
-         "version": "1.0.0-rc.12",
-         "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.12.tgz",
-         "integrity": "sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==",
+         "version": "1.0.0-rc.15",
+         "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
+         "integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
          "cpu": [
             "arm64"
          ],
@@ -911,9 +909,9 @@
          }
       },
       "node_modules/@rolldown/binding-wasm32-wasi": {
-         "version": "1.0.0-rc.12",
-         "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.12.tgz",
-         "integrity": "sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==",
+         "version": "1.0.0-rc.15",
+         "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
+         "integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
          "cpu": [
             "wasm32"
          ],
@@ -921,16 +919,18 @@
          "license": "MIT",
          "optional": true,
          "dependencies": {
-            "@napi-rs/wasm-runtime": "^1.1.1"
+            "@emnapi/core": "1.9.2",
+            "@emnapi/runtime": "1.9.2",
+            "@napi-rs/wasm-runtime": "^1.1.3"
          },
          "engines": {
             "node": ">=14.0.0"
          }
       },
       "node_modules/@rolldown/binding-win32-arm64-msvc": {
-         "version": "1.0.0-rc.12",
-         "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.12.tgz",
-         "integrity": "sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==",
+         "version": "1.0.0-rc.15",
+         "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
+         "integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
          "cpu": [
             "arm64"
          ],
@@ -945,9 +945,9 @@
          }
       },
       "node_modules/@rolldown/binding-win32-x64-msvc": {
-         "version": "1.0.0-rc.12",
-         "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.12.tgz",
-         "integrity": "sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==",
+         "version": "1.0.0-rc.15",
+         "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
+         "integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
          "cpu": [
             "x64"
          ],
@@ -962,9 +962,9 @@
          }
       },
       "node_modules/@rolldown/pluginutils": {
-         "version": "1.0.0-rc.12",
-         "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.12.tgz",
-         "integrity": "sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==",
+         "version": "1.0.0-rc.15",
+         "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
+         "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
          "dev": true,
          "license": "MIT"
       },
@@ -1026,26 +1026,26 @@
          "license": "MIT"
       },
       "node_modules/@types/node": {
-         "version": "25.5.2",
-         "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
-         "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
+         "version": "25.6.0",
+         "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+         "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
          "dev": true,
          "license": "MIT",
          "dependencies": {
-            "undici-types": "~7.18.0"
+            "undici-types": "~7.19.0"
          }
       },
       "node_modules/@vitest/expect": {
-         "version": "4.1.2",
-         "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
-         "integrity": "sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==",
+         "version": "4.1.4",
+         "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
+         "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
          "dev": true,
          "license": "MIT",
          "dependencies": {
             "@standard-schema/spec": "^1.1.0",
             "@types/chai": "^5.2.2",
-            "@vitest/spy": "4.1.2",
-            "@vitest/utils": "4.1.2",
+            "@vitest/spy": "4.1.4",
+            "@vitest/utils": "4.1.4",
             "chai": "^6.2.2",
             "tinyrainbow": "^3.1.0"
          },
@@ -1054,13 +1054,13 @@
          }
       },
       "node_modules/@vitest/mocker": {
-         "version": "4.1.2",
-         "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.2.tgz",
-         "integrity": "sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==",
+         "version": "4.1.4",
+         "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
+         "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
          "dev": true,
          "license": "MIT",
          "dependencies": {
-            "@vitest/spy": "4.1.2",
+            "@vitest/spy": "4.1.4",
             "estree-walker": "^3.0.3",
             "magic-string": "^0.30.21"
          },
@@ -1081,9 +1081,9 @@
          }
       },
       "node_modules/@vitest/pretty-format": {
-         "version": "4.1.2",
-         "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.2.tgz",
-         "integrity": "sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==",
+         "version": "4.1.4",
+         "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
+         "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
          "dev": true,
          "license": "MIT",
          "dependencies": {
@@ -1094,13 +1094,13 @@
          }
       },
       "node_modules/@vitest/runner": {
-         "version": "4.1.2",
-         "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.2.tgz",
-         "integrity": "sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==",
+         "version": "4.1.4",
+         "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
+         "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
          "dev": true,
          "license": "MIT",
          "dependencies": {
-            "@vitest/utils": "4.1.2",
+            "@vitest/utils": "4.1.4",
             "pathe": "^2.0.3"
          },
          "funding": {
@@ -1108,14 +1108,14 @@
          }
       },
       "node_modules/@vitest/snapshot": {
-         "version": "4.1.2",
-         "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.2.tgz",
-         "integrity": "sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==",
+         "version": "4.1.4",
+         "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
+         "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
          "dev": true,
          "license": "MIT",
          "dependencies": {
-            "@vitest/pretty-format": "4.1.2",
-            "@vitest/utils": "4.1.2",
+            "@vitest/pretty-format": "4.1.4",
+            "@vitest/utils": "4.1.4",
             "magic-string": "^0.30.21",
             "pathe": "^2.0.3"
          },
@@ -1124,9 +1124,9 @@
          }
       },
       "node_modules/@vitest/spy": {
-         "version": "4.1.2",
-         "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.2.tgz",
-         "integrity": "sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==",
+         "version": "4.1.4",
+         "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
+         "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
          "dev": true,
          "license": "MIT",
          "funding": {
@@ -1134,13 +1134,13 @@
          }
       },
       "node_modules/@vitest/utils": {
-         "version": "4.1.2",
-         "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.2.tgz",
-         "integrity": "sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==",
+         "version": "4.1.4",
+         "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
+         "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
          "dev": true,
          "license": "MIT",
          "dependencies": {
-            "@vitest/pretty-format": "4.1.2",
+            "@vitest/pretty-format": "4.1.4",
             "convert-source-map": "^2.0.0",
             "tinyrainbow": "^3.1.0"
          },
@@ -1348,6 +1348,12 @@
          "bin": {
             "js-yaml": "bin/js-yaml.js"
          }
+      },
+      "node_modules/json-with-bigint": {
+         "version": "3.5.8",
+         "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.8.tgz",
+         "integrity": "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==",
+         "license": "MIT"
       },
       "node_modules/lightningcss": {
          "version": "1.32.0",
@@ -1687,9 +1693,9 @@
          }
       },
       "node_modules/postcss": {
-         "version": "8.5.8",
-         "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-         "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+         "version": "8.5.10",
+         "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+         "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
          "dev": true,
          "funding": [
             {
@@ -1716,9 +1722,9 @@
          }
       },
       "node_modules/prettier": {
-         "version": "3.8.1",
-         "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
-         "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+         "version": "3.8.3",
+         "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+         "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
          "dev": true,
          "license": "MIT",
          "bin": {
@@ -1732,14 +1738,14 @@
          }
       },
       "node_modules/rolldown": {
-         "version": "1.0.0-rc.12",
-         "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.12.tgz",
-         "integrity": "sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==",
+         "version": "1.0.0-rc.15",
+         "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
+         "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
          "dev": true,
          "license": "MIT",
          "dependencies": {
-            "@oxc-project/types": "=0.122.0",
-            "@rolldown/pluginutils": "1.0.0-rc.12"
+            "@oxc-project/types": "=0.124.0",
+            "@rolldown/pluginutils": "1.0.0-rc.15"
          },
          "bin": {
             "rolldown": "bin/cli.mjs"
@@ -1748,21 +1754,21 @@
             "node": "^20.19.0 || >=22.12.0"
          },
          "optionalDependencies": {
-            "@rolldown/binding-android-arm64": "1.0.0-rc.12",
-            "@rolldown/binding-darwin-arm64": "1.0.0-rc.12",
-            "@rolldown/binding-darwin-x64": "1.0.0-rc.12",
-            "@rolldown/binding-freebsd-x64": "1.0.0-rc.12",
-            "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.12",
-            "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.12",
-            "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.12",
-            "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.12",
-            "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.12",
-            "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.12",
-            "@rolldown/binding-linux-x64-musl": "1.0.0-rc.12",
-            "@rolldown/binding-openharmony-arm64": "1.0.0-rc.12",
-            "@rolldown/binding-wasm32-wasi": "1.0.0-rc.12",
-            "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.12",
-            "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.12"
+            "@rolldown/binding-android-arm64": "1.0.0-rc.15",
+            "@rolldown/binding-darwin-arm64": "1.0.0-rc.15",
+            "@rolldown/binding-darwin-x64": "1.0.0-rc.15",
+            "@rolldown/binding-freebsd-x64": "1.0.0-rc.15",
+            "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15",
+            "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15",
+            "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15",
+            "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15",
+            "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15",
+            "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
+            "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15",
+            "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15",
+            "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
+            "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
+            "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
          }
       },
       "node_modules/semver": {
@@ -1802,9 +1808,9 @@
          "license": "MIT"
       },
       "node_modules/std-env": {
-         "version": "4.0.0",
-         "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
-         "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+         "version": "4.1.0",
+         "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+         "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
          "dev": true,
          "license": "MIT"
       },
@@ -1816,9 +1822,9 @@
          "license": "MIT"
       },
       "node_modules/tinyexec": {
-         "version": "1.0.2",
-         "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
-         "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+         "version": "1.1.1",
+         "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+         "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
          "dev": true,
          "license": "MIT",
          "engines": {
@@ -1826,14 +1832,14 @@
          }
       },
       "node_modules/tinyglobby": {
-         "version": "0.2.15",
-         "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-         "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+         "version": "0.2.16",
+         "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+         "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
          "dev": true,
          "license": "MIT",
          "dependencies": {
             "fdir": "^6.5.0",
-            "picomatch": "^4.0.3"
+            "picomatch": "^4.0.4"
          },
          "engines": {
             "node": ">=12.0.0"
@@ -1884,18 +1890,18 @@
          }
       },
       "node_modules/undici": {
-         "version": "6.24.1",
-         "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
-         "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
+         "version": "6.25.0",
+         "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
+         "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
          "license": "MIT",
          "engines": {
             "node": ">=18.17"
          }
       },
       "node_modules/undici-types": {
-         "version": "7.18.2",
-         "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-         "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+         "version": "7.19.2",
+         "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+         "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
          "dev": true,
          "license": "MIT"
       },
@@ -1906,16 +1912,16 @@
          "license": "ISC"
       },
       "node_modules/vite": {
-         "version": "8.0.5",
-         "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.5.tgz",
-         "integrity": "sha512-nmu43Qvq9UopTRfMx2jOYW5l16pb3iDC1JH6yMuPkpVbzK0k+L7dfsEDH4jRgYFmsg0sTAqkojoZgzLMlwHsCQ==",
+         "version": "8.0.8",
+         "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
+         "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
          "dev": true,
          "license": "MIT",
          "dependencies": {
             "lightningcss": "^1.32.0",
             "picomatch": "^4.0.4",
             "postcss": "^8.5.8",
-            "rolldown": "1.0.0-rc.12",
+            "rolldown": "1.0.0-rc.15",
             "tinyglobby": "^0.2.15"
          },
          "bin": {
@@ -1984,19 +1990,19 @@
          }
       },
       "node_modules/vitest": {
-         "version": "4.1.2",
-         "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.2.tgz",
-         "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
+         "version": "4.1.4",
+         "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
+         "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
          "dev": true,
          "license": "MIT",
          "dependencies": {
-            "@vitest/expect": "4.1.2",
-            "@vitest/mocker": "4.1.2",
-            "@vitest/pretty-format": "4.1.2",
-            "@vitest/runner": "4.1.2",
-            "@vitest/snapshot": "4.1.2",
-            "@vitest/spy": "4.1.2",
-            "@vitest/utils": "4.1.2",
+            "@vitest/expect": "4.1.4",
+            "@vitest/mocker": "4.1.4",
+            "@vitest/pretty-format": "4.1.4",
+            "@vitest/runner": "4.1.4",
+            "@vitest/snapshot": "4.1.4",
+            "@vitest/spy": "4.1.4",
+            "@vitest/utils": "4.1.4",
             "es-module-lexer": "^2.0.0",
             "expect-type": "^1.3.0",
             "magic-string": "^0.30.21",
@@ -2024,10 +2030,12 @@
             "@edge-runtime/vm": "*",
             "@opentelemetry/api": "^1.9.0",
             "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-            "@vitest/browser-playwright": "4.1.2",
-            "@vitest/browser-preview": "4.1.2",
-            "@vitest/browser-webdriverio": "4.1.2",
-            "@vitest/ui": "4.1.2",
+            "@vitest/browser-playwright": "4.1.4",
+            "@vitest/browser-preview": "4.1.4",
+            "@vitest/browser-webdriverio": "4.1.4",
+            "@vitest/coverage-istanbul": "4.1.4",
+            "@vitest/coverage-v8": "4.1.4",
+            "@vitest/ui": "4.1.4",
             "happy-dom": "*",
             "jsdom": "*",
             "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -2049,6 +2057,12 @@
                "optional": true
             },
             "@vitest/browser-webdriverio": {
+               "optional": true
+            },
+            "@vitest/coverage-istanbul": {
+               "optional": true
+            },
+            "@vitest/coverage-v8": {
                "optional": true
             },
             "@vitest/ui": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
    "name": "k8s-deploy-action",
-   "version": "5.1.0",
+   "version": "6.0.0",
    "author": "Deepak Sattiraju",
    "license": "MIT",
    "type": "module",


### PR DESCRIPTION
## Summary

- Bump version to 6.0.0 (major: node20 → node24 runtime upgrade)
- Update CHANGELOG.md with all changes since v5.1.0
- Regenerate package-lock.json

### Breaking Change

- **Node.js runtime upgraded from node20 to node24** (#504). Consumers using `@v5` will need to update to `@v6`.

### Changes since v5.1.0

- #504 Update Node.js runtime from node20 to node24
- #500 Update action version references in README to latest majors
- Security dependency bumps (undici, vite, vitest, actions group)

### Validation

- `tsc --noEmit` ✅
- `npm run build` ✅ (produces valid ESM bundle)
- `npm test` ✅ (254/254 tests pass)
- `npm run format-check` ✅
- `package.json`, `package-lock.json`, `CHANGELOG.md` versions all sync at 6.0.0
- `action.yml` uses `node24` runtime

Merging triggers the release workflow via CHANGELOG push to main.