### PR TITLE
release: v7.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## [7.0.0] - 2026-06-23
+
+### Changed
+
+- #528 [Confine manifest paths to GITHUB_WORKSPACE (**breaking**: workflows passing `manifests:` paths outside the workspace now fail with a clear error)](https://github.com/Azure/k8s-deploy/pull/528)
+- #527 [Pin release workflow to commit SHA for supply chain safety](https://github.com/Azure/k8s-deploy/pull/527)
+
+### Security
+
+- #528 [Harden URL fetcher error handling in writeYamlFromURLToFile](https://github.com/Azure/k8s-deploy/pull/528)
+- #537 [Bump undici from 6.25.0 to 6.27.0](https://github.com/Azure/k8s-deploy/pull/537)
+- #536 [Bump actions/checkout in /.github/workflows in the actions group](https://github.com/Azure/k8s-deploy/pull/536)
+- #534 [Bump the actions group with 3 updates](https://github.com/Azure/k8s-deploy/pull/534)
+- #533 [Bump esbuild from 0.28.0 to 0.28.1](https://github.com/Azure/k8s-deploy/pull/533)
+- #532 [Bump github/codeql-action in /.github/workflows in the actions group](https://github.com/Azure/k8s-deploy/pull/532)
+- #531 [Bump @types/node from 25.9.1 to 25.9.2 in the actions group](https://github.com/Azure/k8s-deploy/pull/531)
+- #530 [Bump the actions group in /.github/workflows with 2 updates](https://github.com/Azure/k8s-deploy/pull/530)
+- #529 [Bump the actions group with 2 updates](https://github.com/Azure/k8s-deploy/pull/529)
+- #526 [Bump the actions group in /.github/workflows with 2 updates](https://github.com/Azure/k8s-deploy/pull/526)
+- #525 [Bump the actions group with 2 updates](https://github.com/Azure/k8s-deploy/pull/525)
+- #524 [Bump @types/node from 25.7.0 to 25.9.0 in the actions group](https://github.com/Azure/k8s-deploy/pull/524)
+- #523 [Bump github/codeql-action in /.github/workflows in the actions group](https://github.com/Azure/k8s-deploy/pull/523)
+
 ## [6.0.0] - 2026-04-17
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Following are the key capabilities of this action:
 ### Basic deployment (without any deployment strategy)
 
 ```yaml
-- uses: Azure/k8s-deploy@v5
+- uses: Azure/k8s-deploy@v7
   with:
      namespace: 'myapp'
      manifests: |
@@ -164,7 +164,7 @@ Following are the key capabilities of this action:
 ### Private cluster deployment
 
 ```yaml
-- uses: Azure/k8s-deploy@v5
+- uses: Azure/k8s-deploy@v7
   with:
      resource-group: yourResourceGroup
      name: yourClusterName
@@ -184,7 +184,7 @@ Following are the key capabilities of this action:
 ### Canary deployment without service mesh
 
 ```yaml
-- uses: Azure/k8s-deploy@v5
+- uses: Azure/k8s-deploy@v7
   with:
      namespace: 'myapp'
      images: 'contoso.azurecr.io/myapp:${{ event.run_id }}'
@@ -203,7 +203,7 @@ Following are the key capabilities of this action:
 To promote/reject the canary created by the above snippet, the following YAML snippet could be used:
 
 ```yaml
-- uses: Azure/k8s-deploy@v5
+- uses: Azure/k8s-deploy@v7
   with:
      namespace: 'myapp'
      images: 'contoso.azurecr.io/myapp:${{ event.run_id }}'
@@ -221,7 +221,7 @@ To promote/reject the canary created by the above snippet, the following YAML sn
 ### Canary deployment based on Service Mesh Interface
 
 ```yaml
-- uses: Azure/k8s-deploy@v5
+- uses: Azure/k8s-deploy@v7
   with:
      namespace: 'myapp'
      images: 'contoso.azurecr.io/myapp:${{ event.run_id }}'
@@ -242,7 +242,7 @@ To promote/reject the canary created by the above snippet, the following YAML sn
 To promote/reject the canary created by the above snippet, the following YAML snippet could be used:
 
 ```yaml
-- uses: Azure/k8s-deploy@v5
+- uses: Azure/k8s-deploy@v7
   with:
      namespace: 'myapp'
      images: 'contoso.azurecr.io/myapp:${{ event.run_id }} '
@@ -261,7 +261,7 @@ To promote/reject the canary created by the above snippet, the following YAML sn
 ### Blue-Green deployment with different route methods
 
 ```yaml
-- uses: Azure/k8s-deploy@v5
+- uses: Azure/k8s-deploy@v7
   with:
      namespace: 'myapp'
      images: 'contoso.azurecr.io/myapp:${{ event.run_id }}'
@@ -281,7 +281,7 @@ To promote/reject the canary created by the above snippet, the following YAML sn
 To promote/reject the green workload created by the above snippet, the following YAML snippet could be used:
 
 ```yaml
-- uses: Azure/k8s-deploy@v5
+- uses: Azure/k8s-deploy@v7
   with:
      namespace: 'myapp'
      images: 'contoso.azurecr.io/myapp:${{ event.run_id }}'
@@ -338,7 +338,7 @@ jobs:
               container-registry-password: ${{ secrets.REGISTRY_PASSWORD }}
               secret-name: demo-k8s-secret
 
-         - uses: Azure/k8s-deploy@v5
+         - uses: Azure/k8s-deploy@v7
            with:
               action: deploy
               manifests: |
@@ -384,7 +384,7 @@ jobs:
               container-registry-password: ${{ secrets.REGISTRY_PASSWORD }}
               secret-name: demo-k8s-secret
 
-         - uses: Azure/k8s-deploy@v5
+         - uses: Azure/k8s-deploy@v7
            with:
               action: deploy
               manifests: |
@@ -468,7 +468,7 @@ jobs:
               helm-version: 'latest'
            id: bake
 
-         - uses: Azure/k8s-deploy@v5
+         - uses: Azure/k8s-deploy@v7
            with:
               action: deploy
               manifests: ${{ steps.bake.outputs.manifestsBundle }}

--- a/README.md
+++ b/README.md
@@ -147,6 +147,21 @@ Following are the key capabilities of this action:
 
 ## Usage Examples
 
+### Pinning the action version
+
+For supply-chain security, GitHub [recommends](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) pinning third-party actions to a full-length commit SHA rather than a mutable tag. The examples below use `Azure/k8s-deploy@v7` for readability, but the pinned form is preferred in production workflows:
+
+```yaml
+# Pinned to a specific commit SHA (recommended)
+- uses: Azure/k8s-deploy@<full-commit-sha> # v7.0.0
+  with:
+     manifests: |
+        deployment.yaml
+        service.yaml
+```
+
+Replace `<full-commit-sha>` with the 40-character commit SHA of the [release](https://github.com/Azure/k8s-deploy/releases) you want to pin to. Dependabot can keep pinned SHAs up to date automatically — see [Keeping your actions up to date with Dependabot](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot).
+
 ### Basic deployment (without any deployment strategy)
 
 ```yaml

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
    "name": "k8s-deploy-action",
-   "version": "6.0.0",
+   "version": "7.0.0",
    "lockfileVersion": 3,
    "requires": true,
    "packages": {
       "": {
          "name": "k8s-deploy-action",
-         "version": "6.0.0",
+         "version": "7.0.0",
          "license": "MIT",
          "dependencies": {
             "@actions/core": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
    "name": "k8s-deploy-action",
-   "version": "6.0.0",
+   "version": "7.0.0",
    "author": "Deepak Sattiraju",
    "license": "MIT",
    "type": "module",


### PR DESCRIPTION
## Summary

Cuts v7.0.0 of `Azure/k8s-deploy`. Merging this PR will trigger `release-pr.yml`, which tags `v7.0.0`, moves the `v7` major tag, and publishes the GitHub Release.

## Breaking change

- **#528** — `manifests:` inputs that resolve outside `GITHUB_WORKSPACE` (via `../`, absolute paths, or symlinks) now fail the action with a clear error. Workflows that depend on reading manifests from outside the workspace (uncommon; mostly self-hosted runners) must move those files into the workspace before invoking this action. This is why the major version is bumped.

## What's included since v6.0.0

14 commits — see `CHANGELOG.md` diff for the full list. Headlines:

| PR | Type | Summary |
|---|---|---|
| #528 | Breaking + Security | Path containment to `GITHUB_WORKSPACE`, URL fetcher hardening |
| #527 | Hardening | Pin release workflow to commit SHA |
| #523–537 | Security | 12 dependabot updates (undici, esbuild, codeql, actions group, @types/node) |

## File changes

- `CHANGELOG.md` — new `[7.0.0]` entry at top, formatted to match prior entries
- `package.json` + `package-lock.json` — `6.0.0` → `7.0.0`
- `README.md` — bumped 11 usage examples from `Azure/k8s-deploy@v5` → `@v7` (note: `@v5` was never updated to `@v6` in #500, so this catches up to two majors at once)

## Pre-merge checklist

- [x] `npm ci` clean
- [x] `npm run typecheck` clean
- [x] `npm run build` clean (esbuild bundle 1.1mb)
- [x] `npm test` — 271/271 passing (one cleanup-timing test from #528 was flaky on first run; consistently passes on retry, worth a follow-up)
- [x] CHANGELOG entry matches existing format, version bumped in `package.json` + lockfile
- [x] README `@v5` → `@v7` (11 occurrences)
- [ ] Reviewed by a second maintainer

## Post-merge verification

- [ ] `Release Project` workflow run is green
- [ ] `gh release view v7.0.0 --repo Azure/k8s-deploy` exists with the changelog body
- [ ] `git ls-remote --tags https://github.com/Azure/k8s-deploy.git | grep -E 'v7(\.0\.0)?$'` shows both `v7` and `v7.0.0` at the merge SHA
- [ ] Trigger one downstream consumer pinned to `@v7` and confirm it runs

## Follow-ups (not blocking)

- Stabilize the `removes temp file on mid-stream response error` test in `fileUtils.test.ts` — likely needs a deterministic wait for the cleanup promise rather than `waitForCleanup()`.