### PR TITLE
fix: strip colon from parsed NewReplicaSet name

### DIFF
--- a/src/types/kubectl.test.ts
+++ b/src/types/kubectl.test.ts
@@ -635,11 +635,11 @@ describe('Kubectl class', () => {
    it('gets new replica sets', async () => {
       const kubectl = new Kubectl(kubectlPath, testNamespace)
 
-      const newReplicaSetName = 'newreplicaset'
+      const newReplicaSetName = 'newreplicaset:'
       const name = 'name'
       const describeReturn = {
          exitCode: 0,
-         stdout: newReplicaSetName + name + ' ' + 'extra',
+         stdout: newReplicaSetName + ' ' + name + ' ' + 'extra',
          stderr: ''
       }
 

--- a/src/types/kubectl.ts
+++ b/src/types/kubectl.ts
@@ -85,7 +85,7 @@ export class Kubectl {
          const stdout = result.stdout.split('\n')
          core.debug('stdout from getNewReplicaSet is ' + JSON.stringify(stdout))
          stdout.forEach((line: string) => {
-            const newreplicaset = 'newreplicaset'
+            const newreplicaset = 'newreplicaset:'
             if (line && line.toLowerCase().indexOf(newreplicaset) > -1) {
                core.debug(
                   `found string of interest for replicaset, line is ${line}`

--- a/src/utilities/githubUtils.ts
+++ b/src/utilities/githubUtils.ts
@@ -44,7 +44,8 @@ export function normalizeWorkflowStrLabel(workflowName: string): string {
 export function getNormalizedPath(pathValue: string) {
    if (!isHttpUrl(pathValue)) {
       //if it is not an http url then convert to link from current repo and commit
-      return `https://github.com/${process.env.GITHUB_REPOSITORY}/blob/${process.env.GITHUB_SHA}/${pathValue}`
+      const serverUrl = process.env.GITHUB_SERVER_URL || 'https://github.com'
+      return `${serverUrl}/${process.env.GITHUB_REPOSITORY}/blob/${process.env.GITHUB_SHA}/${pathValue}`
    }
    return pathValue
 }

--- a/src/utilities/workflowAnnotationUtils.ts
+++ b/src/utilities/workflowAnnotationUtils.ts
@@ -16,7 +16,11 @@ export function getWorkflowAnnotations(
       workflowFileName: workflowFilePath.replace('.github/workflows/', ''),
       jobName: process.env.GITHUB_JOB,
       createdBy: process.env.GITHUB_ACTOR,
-      runUri: `https://github.com/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`,
+      runUri: `${
+         process.env.GITHUB_SERVER_URL || 'https://github.com'
+      }/${process.env.GITHUB_REPOSITORY}/actions/runs/${
+         process.env.GITHUB_RUN_ID
+      }`,
       commit: process.env.GITHUB_SHA,
       lastSuccessRunCommit: lastSuccessRunSha,
       branch: process.env.GITHUB_REF,


### PR DESCRIPTION
Include the trailing colon in the 'newreplicaset:' keyword so substring() removes "NewReplicaSet:" entirely. Previously the colon was left behind, causing getNewReplicaSet to return ":" instead of the actual ReplicaSet name.

Also update the getNewReplicaSet unit test to use realistic colon-delimited `kubectl describe` output, which the previous mock omitted.

Resolves azure/k8s-deploy#318