### PR TITLE
fix: support GitHub Enterprise Server domains in annotation URLs

### DIFF
--- a/src/utilities/githubUtils.test.ts
+++ b/src/utilities/githubUtils.test.ts
@@ -36,6 +36,21 @@ describe('Github utils', () => {
       )
    })
 
+   it('normalizes path with a custom server url', () => {
+      const serverUrl = 'https://github.enterprise.com'
+      const repo = 'gh_repo'
+      const sha = 'gh_sha'
+      const path = 'path'
+      process.env.GITHUB_SERVER_URL = serverUrl
+      process.env.GITHUB_REPOSITORY = repo
+      process.env.GITHUB_SHA = sha
+      expect(getNormalizedPath(path)).toBe(
+         `${serverUrl}/${repo}/blob/${sha}/${path}`
+      )
+
+      delete process.env.GITHUB_SERVER_URL
+   })
+
    it('checks if url is http', () => {
       expect(isHttpUrl('www.test.com')).toBe(false)
       expect(isHttpUrl('http.test.com')).toBe(false)

--- a/src/utilities/githubUtils.ts
+++ b/src/utilities/githubUtils.ts
@@ -44,7 +44,8 @@ export function normalizeWorkflowStrLabel(workflowName: string): string {
 export function getNormalizedPath(pathValue: string) {
    if (!isHttpUrl(pathValue)) {
       //if it is not an http url then convert to link from current repo and commit
-      return `https://github.com/${process.env.GITHUB_REPOSITORY}/blob/${process.env.GITHUB_SHA}/${pathValue}`
+      const serverUrl = process.env.GITHUB_SERVER_URL || 'https://github.com'
+      return `${serverUrl}/${process.env.GITHUB_REPOSITORY}/blob/${process.env.GITHUB_SHA}/${pathValue}`
    }
    return pathValue
 }

--- a/src/utilities/workflowAnnotationUtils.ts
+++ b/src/utilities/workflowAnnotationUtils.ts
@@ -16,7 +16,11 @@ export function getWorkflowAnnotations(
       workflowFileName: workflowFilePath.replace('.github/workflows/', ''),
       jobName: process.env.GITHUB_JOB,
       createdBy: process.env.GITHUB_ACTOR,
-      runUri: `https://github.com/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`,
+      runUri: `${
+         process.env.GITHUB_SERVER_URL || 'https://github.com'
+      }/${process.env.GITHUB_REPOSITORY}/actions/runs/${
+         process.env.GITHUB_RUN_ID
+      }`,
       commit: process.env.GITHUB_SHA,
       lastSuccessRunCommit: lastSuccessRunSha,
       branch: process.env.GITHUB_REF,

--- a/src/utilities/workflowAnnotationUtils.ts
+++ b/src/utilities/workflowAnnotationUtils.ts
@@ -9,6 +9,8 @@ export function getWorkflowAnnotations(
    workflowFilePath: string,
    deploymentConfig: DeploymentConfig
 ): string {
+   const serverUrl = process.env.GITHUB_SERVER_URL || 'https://github.com'
+   const runUri = `${serverUrl}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
    const annotationObject = {
       run: process.env.GITHUB_RUN_ID,
       repository: process.env.GITHUB_REPOSITORY,
@@ -16,11 +18,7 @@ export function getWorkflowAnnotations(
       workflowFileName: workflowFilePath.replace('.github/workflows/', ''),
       jobName: process.env.GITHUB_JOB,
       createdBy: process.env.GITHUB_ACTOR,
-      runUri: `${
-         process.env.GITHUB_SERVER_URL || 'https://github.com'
-      }/${process.env.GITHUB_REPOSITORY}/actions/runs/${
-         process.env.GITHUB_RUN_ID
-      }`,
+      runUri,
       commit: process.env.GITHUB_SHA,
       lastSuccessRunCommit: lastSuccessRunSha,
       branch: process.env.GITHUB_REF,


### PR DESCRIPTION
Replace hardcoded https://github.com in the deployment annotation runUri and getNormalizedPath blob links with GITHUB_SERVER_URL, falling back to https://github.com when the var is unset. This makes the generated links correct on GitHub Enterprise Server instances hosted on custom domains.

This PR fixes issue 
This pull request improves how URLs are constructed for GitHub resources by ensuring that the correct GitHub server URL is used, especially in environments where GitHub Enterprise or custom domains are in use. The changes make the code more flexible and robust for different deployment scenarios.

**URL Construction Improvements:**

* Updated `getNormalizedPath` in `src/utilities/githubUtils.ts` to use `GITHUB_SERVER_URL` (defaulting to `https://github.com`) when constructing blob URLs, instead of hardcoding the domain.
* Updated `getWorkflowAnnotations` in `src/utilities/workflowAnnotationUtils.ts` to use `GITHUB_SERVER_URL` (defaulting to `https://github.com`) when constructing workflow run URLs, instead of hardcoding the domain.
* This PR fixes issue #201 