### PR TITLE
fix: strip colon from parsed NewReplicaSet name

### DIFF
--- a/src/types/kubectl.test.ts
+++ b/src/types/kubectl.test.ts
@@ -635,11 +635,11 @@ describe('Kubectl class', () => {
    it('gets new replica sets', async () => {
       const kubectl = new Kubectl(kubectlPath, testNamespace)
 
-      const newReplicaSetName = 'newreplicaset'
+      const newReplicaSetName = 'newreplicaset:'
       const name = 'name'
       const describeReturn = {
          exitCode: 0,
-         stdout: newReplicaSetName + name + ' ' + 'extra',
+         stdout: newReplicaSetName + ' ' + name + ' ' + 'extra',
          stderr: ''
       }
 

--- a/src/types/kubectl.test.ts
+++ b/src/types/kubectl.test.ts
@@ -635,11 +635,10 @@ describe('Kubectl class', () => {
    it('gets new replica sets', async () => {
       const kubectl = new Kubectl(kubectlPath, testNamespace)
 
-      const newReplicaSetName = 'newreplicaset:'
-      const name = 'name'
+      const name = 'my-app-6d4cf56db6'
       const describeReturn = {
          exitCode: 0,
-         stdout: newReplicaSetName + ' ' + name + ' ' + 'extra',
+         stdout: `NewReplicaSet: ${name} (1/1 replicas created)`,
          stderr: ''
       }
 

--- a/src/types/kubectl.ts
+++ b/src/types/kubectl.ts
@@ -85,7 +85,7 @@ export class Kubectl {
          const stdout = result.stdout.split('\n')
          core.debug('stdout from getNewReplicaSet is ' + JSON.stringify(stdout))
          stdout.forEach((line: string) => {
-            const newreplicaset = 'newreplicaset'
+            const newreplicaset = 'newreplicaset:'
             if (line && line.toLowerCase().indexOf(newreplicaset) > -1) {
                core.debug(
                   `found string of interest for replicaset, line is ${line}`


### PR DESCRIPTION
This pull request makes a minor adjustment to the way new replica sets are identified in both the `Kubectl` class and its associated test. The change ensures that the string `'newreplicaset:'` (with a colon) is used as the identifier instead of `'newreplicaset'` (without a colon), improving the accuracy of matching lines related to new replica sets.

- **Bug fix: Replica set identification**
  * Updated the identifier from `'newreplicaset'` to `'newreplicaset:'` in both the `Kubectl` class and its test to ensure correct parsing of replica set lines. [[1]](diffhunk://#diff-e4178a3dbfa2c0baa024b18b3682b15e5e4564bccf73205533eaca0b34708970L88-R88) [[2]](diffhunk://#diff-362988a4ed51ef5a7abb79980ebd597b77eabeea056d810623431c160f410059L638-R642)Include the trailing colon in the 'newreplicaset:' keyword so substring() removes "NewReplicaSet:" entirely. Previously the colon was left behind, causing getNewReplicaSet to return ":" instead of the actual ReplicaSet name.

Also update the getNewReplicaSet unit test to use realistic colon-delimited `kubectl describe` output, which the previous mock omitted.

Resolves azure/k8s-deploy#318