### PR TITLE
docs: require k8s-bake v4.1.1+ in the bake example

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,13 @@ jobs:
 
 ### Use bake action to get manifests deploying to a Kubernetes cluster
 
+> **Requires `azure/k8s-bake@v4.1.1` or later.** Since v7, `k8s-deploy` rejects
+> `manifests:` paths that resolve outside `GITHUB_WORKSPACE`. Earlier versions of
+> `k8s-bake` wrote the baked manifest to `RUNNER_TEMP`, which is a sibling of the
+> workspace on hosted runners, so `manifestsBundle` was rejected. `k8s-bake` v4.1.1
+> writes into the workspace instead ([Azure/k8s-bake#289](https://github.com/Azure/k8s-bake/pull/289)).
+> Workflows that pass `manifestsBundle` need no other changes.
+
 ```yaml
 on: [push]
 env:
@@ -473,7 +480,7 @@ jobs:
               container-registry-password: ${{ secrets.REGISTRY_PASSWORD }}
               secret-name: demo-k8s-secret
 
-         - uses: azure/k8s-bake@v3
+         - uses: azure/k8s-bake@v4
            with:
               renderEngine: 'helm'
               helmChart: './aks-helloworld/'


### PR DESCRIPTION
## Problem

The "Use bake action to get manifests" example pairs `azure/k8s-bake@v3` with `Azure/k8s-deploy@v7`. That combination cannot work.

Since v7, `assertPathWithinWorkspace` (#528) rejects `manifests:` paths resolving outside `GITHUB_WORKSPACE`. `k8s-bake` before v4.1.1 wrote the baked manifest to `RUNNER_TEMP`, which is a *sibling* of the workspace on hosted runners:

```
/home/runner/work/
├── _temp/          <- k8s-bake <4.1.1 output
└── my-repo/
    └── my-repo/    <- GITHUB_WORKSPACE
```

So copying the documented example fails with:

```
manifest path /home/runner/work/_temp/baked-template-<ts>.yaml resolves to ...,
which is outside the workspace /home/runner/work/my-repo/my-repo
```

## Fix

`k8s-bake` v4.1.1 writes to `$GITHUB_WORKSPACE/.k8s-bake/` instead ([Azure/k8s-bake#289](https://github.com/Azure/k8s-bake/pull/289)), so the chain works again with **no change needed on the `k8s-deploy` side** — the workspace confinement is working as designed.

This PR only fixes the documentation:
- bake example bumped `@v3` → `@v4`
- added a note stating the v4.1.1 minimum and why

The gap this closes: nothing in this repo currently tells users that a `k8s-bake` upgrade is the remedy. The v7.0.0 changelog entry describes the confinement but never mentions the bake version requirement, so anyone on `k8s-bake@v3` or `v4.1.0` has no signal pointing at the fix.

Fixes #553.

#553 had two halves. The runtime failure is already fixed upstream by
[Azure/k8s-bake#289](https://github.com/Azure/k8s-bake/pull/289) (released in bake v4.1.1) — no code change is
needed here, since the workspace confinement is working as designed. The remaining half was
documentation: this repo still shipped the failing example and gave no indication that a `k8s-bake`
upgrade was the remedy. This PR closes that half, so #553 can close when it merges.

## Test plan

- [x] `prettier --check README.md` passes
- [x] Confirmed `assertPathWithinWorkspace` is still present in `src/utilities/fileUtils.ts` on `main` (behavior intentionally unchanged)
- [x] Confirmed `k8s-bake` `main` writes to `$GITHUB_WORKSPACE/.k8s-bake/` via `getBakedManifestPath()`
