### PR TITLE
release: v7.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [7.0.1] - 2026-08-31
+
+### Security
+
+- #560 [Fix command injection in `az aks command invoke` for private clusters: argv is now POSIX-quoted instead of flattened with `join(' ')`, so manifest resource names, the `namespace` input and the workflow annotation payload can no longer escape into the run-command pod's high-privilege service account](https://github.com/Azure/k8s-deploy/pull/560)
+- #552 [Bump js-yaml from 5.2.1 to 5.2.2](https://github.com/Azure/k8s-deploy/pull/552)
+- #551 [Bump postcss from 8.5.15 to 8.5.25](https://github.com/Azure/k8s-deploy/pull/551)
+- #550 [Bump js-yaml from 4.2.0 to 4.3.0](https://github.com/Azure/k8s-deploy/pull/550)
+- #548 [Bump the actions group across 1 directory with 6 updates](https://github.com/Azure/k8s-deploy/pull/548)
+- #547 [Bump the actions group across 1 directory with 5 updates](https://github.com/Azure/k8s-deploy/pull/547)
+
+### Fixed
+
+- #543 [Strip trailing colon from the parsed `NewReplicaSet` name in rollout status output](https://github.com/Azure/k8s-deploy/pull/543)
+- #560 [Honour the caller's `silent` flag in `PrivateKubectl.execute`; command output was previously written to the debug log unconditionally](https://github.com/Azure/k8s-deploy/pull/560)
+
+### Changed
+
+- #560 [Remove the unused `minimist` dependency](https://github.com/Azure/k8s-deploy/pull/560)
+- #555 [Document that the `k8s-bake` example requires `k8s-bake` v4.1.1+, which writes its baked manifest inside `GITHUB_WORKSPACE`](https://github.com/Azure/k8s-deploy/pull/555)
+
 ## [7.0.0] - 2026-06-23
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
    "name": "k8s-deploy-action",
-   "version": "7.0.0",
+   "version": "7.0.1",
    "lockfileVersion": 3,
    "requires": true,
    "packages": {
       "": {
          "name": "k8s-deploy-action",
-         "version": "7.0.0",
+         "version": "7.0.1",
          "license": "MIT",
          "dependencies": {
             "@actions/core": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
    "name": "k8s-deploy-action",
-   "version": "7.0.0",
+   "version": "7.0.1",
    "author": "Deepak Sattiraju",
    "license": "MIT",
    "type": "module",


### PR DESCRIPTION
## Summary

Cuts v7.0.1 of `Azure/k8s-deploy`. Merging this PR triggers `release-pr.yml`, which tags `v7.0.1`, moves the `v7` major tag, and publishes the GitHub Release.

Patch release: fixes, one security fix, docs, and dependency bumps. No breaking changes, no new features, so the `v7` major tag moves safely for existing consumers.

## Security

**#560 — command injection in `az aks command invoke`.** `PrivateKubectl.execute` flattened its argv array with `args.join(' ')` and passed the result to `az aks command invoke --command`. The run-command pod uses its own high-privilege service account, so this escaped whatever RBAC the workflow's kubeconfig was scoped to.

Values that reached the command string unescaped:

- manifest `metadata.name`, via the temp filename passed to `-f`
- the `namespace` input, which workflows commonly build from `github.head_ref` (git permits `;`, `$`, `` ` ``, `|`, `&` in branch names)
- the workflow annotation payload — unescaped JSON with spaces and double quotes

## What's included since v7.0.0

8 commits.

| PR | Type | Summary |
|---|---|---|
| #560 | Security | POSIX-quote argv for `az aks command invoke`; honour `silent`; drop unused `minimist` |
| #543 | Fixed | Strip trailing colon from parsed `NewReplicaSet` name |
| #555 | Docs | Require `k8s-bake` v4.1.1+ in the bake example |
| #547, #548, #550, #551, #552 | Dependencies | dependabot bumps (js-yaml, postcss, actions groups) |

## File changes

- `CHANGELOG.md` — new `[7.0.1]` entry, formatted to match prior entries
- `package.json` + `package-lock.json` — `7.0.0` → `7.0.1`

`README.md` already references `@v7`, so no doc bump is needed for a patch. `lib/` is gitignored and built at release time.
